### PR TITLE
Make function scripts always succeed instead of always fail

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -50,7 +50,7 @@ export default class Scripts {
     const name = fn.name || "[Function]";
     console.log(`⚡️ ${brightGreen(name + "()")}`);
     await fn(this.site);
-    return 0;
+    return true;
   }
 
   async #runCommand(options, command) {


### PR DESCRIPTION
I made a GitHub Actions workflow where one step ran a JS function script, and found it returned an error exit code. Looking at the code, it was hardcoded to always fail. I'm guessing this was not intentional, so here's quick fix for it, so now JS function scripts always succeed (Lume returns success exit code).