### PR TITLE
Make slugifier better

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -81,41 +81,16 @@ export function normalizePath(path) {
   return path;
 }
 
-export const slugChars = new Map([
-  ["á", "a"],
-  ["à", "a"],
-  ["â", "a"],
-  ["ã", "a"],
-  ["ä", "a"],
-  ["å", "a"],
-  ["é", "e"],
-  ["è", "e"],
-  ["ê", "e"],
-  ["ë", "e"],
-  ["ì", "i"],
-  ["í", "i"],
-  ["î", "i"],
-  ["ï", "i"],
-  ["ò", "o"],
-  ["ó", "o"],
-  ["ô", "o"],
-  ["õ", "o"],
-  ["ö", "o"],
-  ["ð", "d"],
-  ["ù", "u"],
-  ["ú", "u"],
-  ["ü", "u"],
-  ["û", "u"],
-  ["ñ", "n"],
-  ["ª", "a"],
-  ["º", "o"],
-  ["ç", "c"],
-]);
-
 export function slugify(string) {
+  const chars = new Map([
+    ["ð", "d"],
+    ["ß", "ss"],
+  ]);
+
   return string.toLowerCase()
-    .replaceAll(/[\s-_]+/g, () => "-")
-    .replaceAll(/[^\w-\/]/g, (char) => slugChars.get(char) || "");
+    .normalize("NFKD")
+    .replaceAll(/[\s_-]+/g, "-")
+    .replaceAll(/[^\w\/-]/g, (char) => chars.get(char) || "");
 }
 
 export function searchByExtension(path, extensions) {


### PR DESCRIPTION
* Added Unicode normalization, which handles most of the slug characters. This way we don’t need to list lots of characters.
* Moved the hyphen at the end of the character classes, so it’s clearer that it represents a literal hyphen and not a character range.
* Added ß to the character list.
* Moved the character list inside the function, because it doesn’t need to be exported. *(Or does it?)*
* Replaced the unnecessary function with a string.