### PR TITLE
Use new highlight.js API

### DIFF
--- a/engines/markdown.js
+++ b/engines/markdown.js
@@ -27,7 +27,8 @@ function createMarkdown(site) {
     highlight(str, lang) {
       if (lang && hljs.getLanguage(lang)) {
         try {
-          const code = hljs.highlight(lang, str, true).value;
+          const options = { language: lang, ignoreIllegals: true };
+          const code = hljs.highlight(str, options).value;
           return `<pre class="hljs"><code>${code}</code></pre>`;
         } catch (__) {
           // Ignore error


### PR DESCRIPTION
The old API was deprecated in [highlight.js v10.7.0](https://github.com/highlightjs/highlight.js/releases/tag/10.7.0).