### PR TITLE
Add single-letter aliases for --dev and --port

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -45,10 +45,10 @@ OPTIONS:
         --dest     <dir>    the build destination.              Default: _site
         --config   <file>   specify the lume config file.       Default: _config.js
         --location <url>    set the domain for your site.       Default: http://localhost
-        --dev               enable dev mode (view draft pages)
+    -d, --dev               enable dev mode (view draft pages)
 
     -s, --serve             start a live-reloading web server
-        --port     <port>   the port the server is on           Default: 3000
+    -p, --port     <port>   the port the server is on           Default: 3000
 `;
 
 if (import.meta.main) {

--- a/cli/build.js
+++ b/cli/build.js
@@ -17,16 +17,16 @@ OPTIONS:
         --dest     <dir>    the build destination.              Default: _site
         --config   <file>   specify the lume config file.       Default: _config.js
         --location <url>    set the domain for your site.       Default: http://localhost
-        --dev               enable dev mode (view draft pages)
+    -d, --dev               enable dev mode (view draft pages)
 
     -s, --serve             start a live-reloading web server
-        --port     <port>   the port the server is on           Default: 3000
+    -p, --port     <port>   the port the server is on           Default: 3000
 `;
 export async function run(args, userSite) {
   const options = parse(args, {
     boolean: ["serve", "dev"],
     string: ["port", "src", "dest", "location", "root", "config"],
-    alias: { serve: "s" },
+    alias: { dev: "d", serve: "s", port: "p" },
     ["--"]: true,
     unknown(option) {
       if (option.startsWith("-")) {


### PR DESCRIPTION
It would be very handy to be able to write `lume -sd` or `lume -sdp 80`, for example.