### PR TITLE
Fix linting errors

### DIFF
--- a/cli/update.js
+++ b/cli/update.js
@@ -39,8 +39,8 @@ export async function run(args) {
 
   const content = await Deno.readTextFile(options.config);
   const updated = content.replaceAll(
-    /https:\/\/deno\.land\/x\/lume(@v[\d\.]+)?\/(.*)/g,
-    (m, v, path) => `https://deno.land/x/lume@${version}/${path}`,
+    /https:\/\/deno\.land\/x\/lume(?:@v[\d\.]+)?\/(.*)/g,
+    (_m, path) => `https://deno.land/x/lume@${version}/${path}`,
   );
 
   if (content === updated) {

--- a/deps/util.js
+++ b/deps/util.js
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.93.0/io/util.ts";

--- a/engines/templateEngine.js
+++ b/engines/templateEngine.js
@@ -7,11 +7,11 @@ export default class TemplateEngine {
     this.options = options;
   }
 
-  render(content, data, filename) {
+  render(_content, _data, _filename) {
     // To extend
   }
 
-  addFilter(name, fn, async) {
+  addFilter(_name, _fn, _async) {
     // To extend
   }
 

--- a/plugins/inline.js
+++ b/plugins/inline.js
@@ -1,4 +1,4 @@
-import { extname, join, posix, relative, resolve } from "../deps/path.js";
+import { extname, posix, resolve } from "../deps/path.js";
 import { DOMParser } from "../deps/dom.js";
 import { encode } from "../deps/base64.js";
 import { mimes } from "../utils.js";

--- a/plugins/markdown.js
+++ b/plugins/markdown.js
@@ -49,7 +49,7 @@ function createMarkdown(site, options) {
         try {
           const html = hljs.highlight(code, { language, ignoreIllegals: true });
           return `<pre class="hljs"><code>${html.value}</code></pre>`;
-        } catch (__) {
+        } catch {
           // Ignore error
         }
       }

--- a/plugins/url.js
+++ b/plugins/url.js
@@ -14,7 +14,7 @@ export default function () {
     function htmlUrl(html = "", absolute = false) {
       return html.replaceAll(
         /\s(href|src)="([^"]+)"/g,
-        (match, attr, value) => ` ${attr}="${url(value, absolute)}"`,
+        (_match, attr, value) => ` ${attr}="${url(value, absolute)}"`,
       );
     }
   };

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ import { brightGreen, red } from "./deps/colors.js";
 import { exists } from "./deps/fs.js";
 import localIp from "./deps/local-ip.js";
 import { mimes, normalizePath } from "./utils.js";
+import { readAll } from "./deps/util.js";
 
 const script = `
 let ws;
@@ -186,12 +187,12 @@ export async function server(site, options) {
             ? getHtmlBody(path)
             : getBody(path)),
         });
-      } catch (err) {
+      } catch {
         return;
       }
 
       console.log(`${brightGreen("200")} ${req.url}`);
-    } catch (err) {
+    } catch {
       console.log(`${red("404")} ${req.url}`);
 
       try {
@@ -202,7 +203,7 @@ export async function server(site, options) {
           }),
           body: await getNotFoundBody(root, page404, path),
         });
-      } catch (err) {
+      } catch {
         return;
       }
     }
@@ -302,7 +303,7 @@ async function getNotFoundBody(root, page404, file) {
 
 async function getBody(path) {
   const file = await Deno.open(path);
-  const content = await Deno.readAll(file);
+  const content = await readAll(file);
   Deno.close(file.rid);
 
   return content;

--- a/site.js
+++ b/site.js
@@ -326,7 +326,9 @@ export default class Site {
       // Absolute urls are returned as is
       try {
         return new URL(path).toString();
-      } catch {}
+      } catch {
+        // Ignore error
+      }
     }
 
     if (!this.options.location) {


### PR DESCRIPTION
* Prefix unused parameters with an underscore.
* Use a non-capturing group to avoid an unused parameter.
* Remove unused named imports.
* Remove unused `catch` parameters.
* Replace the deprecated `Deno.readAll` with `readAll` from `std/io/util.ts`.
* Add a comment to an empty `catch` block.