### PR TITLE
Rename SOME operator to ANY

### DIFF
--- a/helpers/search.js
+++ b/helpers/search.js
@@ -153,15 +153,15 @@ function compileCondition(key, value) {
     return `page.${path}?.endsWith(${value})`;
   }
 
-  if (operator === "~=") {
+  if (operator === "*=") {
     return `page.${path}?.includes(${value})`;
   }
 
-  if (operator === "ALL") {
+  if (operator === "&=") {
     return `${value}.every((i) => page.${path}?.includes(i))`;
   }
 
-  if (operator === "SOME") {
+  if (operator === "|=") {
     return `${value}.some((i) => page.${path}?.includes(i))`;
   }
 


### PR DESCRIPTION
`SOME` feels like a plural, even though only one match is required. Also, the `ALL` and `SOME` operators are not documented. Are they really supported?