### PR TITLE
Update markdown-it

### DIFF
--- a/deps/markdown-it.js
+++ b/deps/markdown-it.js
@@ -1,4 +1,4 @@
-export { default as markdownIt } from "https://jspm.dev/markdown-it@12.0.5";
+export { default as markdownIt } from "https://jspm.dev/markdown-it@12.0.6";
 export { default as markdownItAttrs } from "https://jspm.dev/markdown-it-attrs@4.0.0";
 export { default as markdownItReplaceLinks } from "https://jspm.dev/markdown-it-replace-link@1.1.0";
 export { default as markdownItDeflist } from "https://jspm.dev/markdown-it-deflist@2.1.0";


### PR DESCRIPTION
Updates `markdown-it` from `12.0.5` to `12.0.6`.