### PR TITLE
Remove `hljs` class from blocks of unhighlighted code

### DIFF
--- a/plugins/markdown.js
+++ b/plugins/markdown.js
@@ -54,9 +54,7 @@ function createMarkdown(site, options) {
         }
       }
 
-      return `<pre class="hljs"><code>${
-        markdown.utils.escapeHtml(code)
-      }</code></pre>`;
+      return `<pre><code>${markdown.utils.escapeHtml(code)}</code></pre>`;
     },
   });
 


### PR DESCRIPTION
~The HTML spec [recommends](https://html.spec.whatwg.org/#the-code-element) using a `language-*` class in the `<code>` element. Also,~ I don’t think there should be any class for a block of unhighlighted code.

<details>
<summary>Original commit</summary>

```diff
From aff30c3070e9bd23abafa85a10837575b8adc914 Mon Sep 17 00:00:00 2001
From: Valtteri Laitinen <dev@valtlai.fi>
Date: Mon, 19 Apr 2021 17:34:59 +0300
Subject: [PATCH] Add `language-*` class to `<code>` and remove `hljs` class
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit

The HTML spec recommends using a `language-*` class
in the `<code>` element
(https://html.spec.whatwg.org/#the-code-element).

Also, I don’t think there should be any class
for a block of unhighlighted code.
---
 plugins/markdown.js | 6 ++----
 1 file changed, 2 insertions(+), 4 deletions(-)

diff --git a/plugins/markdown.js b/plugins/markdown.js
index defd300..be60ccb 100644
--- a/plugins/markdown.js
+++ b/plugins/markdown.js
@@ -48,15 +48,13 @@ function createMarkdown(site, options) {
       if (language && hljs.getLanguage(language)) {
         try {
           const html = hljs.highlight(code, { language, ignoreIllegals: true });
-          return `<pre class="hljs"><code>${html.value}</code></pre>`;
+          return `<pre><code class="language-${language}">${html.value}</code></pre>`;
         } catch {
           // Ignore error
         }
       }
 
-      return `<pre class="hljs"><code>${
-        markdown.utils.escapeHtml(code)
-      }</code></pre>`;
+      return `<pre><code>${markdown.utils.escapeHtml(code)}</code></pre>`;
     },
   });
 
```
</details>