### PR TITLE
Optionally support async render functions for JSX pages

### DIFF
--- a/engines/jsx.js
+++ b/engines/jsx.js
@@ -7,14 +7,14 @@ if (!globalThis.React) {
 import Module from "./module.js";
 
 export default class Jsx extends Module {
-  render(content, data) {
+  async render(content, data) {
     if (!data.children && data.content) {
       data.children = React.createElement("div", {
         dangerouslySetInnerHTML: { __html: data.content },
       });
     }
 
-    const element = super.render(content, data);
+    const element = await Promise.resolve(super.render(content, data));
     data.children = element;
 
     return ReactDOMServer.renderToStaticMarkup(element);

--- a/engines/jsx.js
+++ b/engines/jsx.js
@@ -14,7 +14,7 @@ export default class Jsx extends Module {
       });
     }
 
-    const element = await Promise.resolve(super.render(content, data));
+    const element = await super.render(content, data);
     data.children = element;
 
     return ReactDOMServer.renderToStaticMarkup(element);


### PR DESCRIPTION
It looks like engines already support async `render` functions, so I figured it would make sense to enable this functionality for JSX pages. Note that I'm using `await Promise.resolve(...)` as [according to the MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve#parameters), this method can both safely wrap an existing Promise or a regular value. This means that this change should remain backward compatible for normal non-async page functions.