### PR TITLE
Nunjuck plugin constructor options

### DIFF
--- a/engines/nunjucks.js
+++ b/engines/nunjucks.js
@@ -8,7 +8,7 @@ export default class Denjucks extends TemplateEngine {
     super(site, options);
 
     const loader = new nunjucks.FileSystemLoader(this.includes);
-    this.engine = new nunjucks.Environment(loader);
+    this.engine = new nunjucks.Environment(loader, options);
 
     // Update cache
     site.addEventListener("beforeUpdate", (ev) => {

--- a/engines/nunjucks.js
+++ b/engines/nunjucks.js
@@ -4,7 +4,7 @@ import TemplateEngine from "./template_engine.js";
 export default class Denjucks extends TemplateEngine {
   cache = new Map();
 
-  constructor(site, options = {}) {
+  constructor(site, options) {
     super(site, options);
 
     const loader = new nunjucks.FileSystemLoader(this.includes);

--- a/plugins/nunjucks.js
+++ b/plugins/nunjucks.js
@@ -4,13 +4,14 @@ import { merge } from "../utils.js";
 // Default options
 const defaults = {
   extensions: [".njk", ".html"],
+  options: {},
 };
 
 export default function (userOptions) {
   const options = merge(defaults, userOptions);
 
   return (site) => {
-    const nunjucksEngine = new NunjucksEngine(site, userOptions);
+    const nunjucksEngine = new NunjucksEngine(site, options.options);
 
     site.engine(options.extensions, nunjucksEngine);
     site.filter("njk", filter, true);

--- a/plugins/nunjucks.js
+++ b/plugins/nunjucks.js
@@ -10,7 +10,7 @@ export default function (userOptions) {
   const options = merge(defaults, userOptions);
 
   return (site) => {
-    const nunjucksEngine = new NunjucksEngine(site);
+    const nunjucksEngine = new NunjucksEngine(site, userOptions);
 
     site.engine(options.extensions, nunjucksEngine);
     site.filter("njk", filter, true);


### PR DESCRIPTION
This pipes the options from `pluginOptions` to the Nunjuck's environment constructor.