### PR TITLE
changed page url generation

### DIFF
--- a/site.js
+++ b/site.js
@@ -486,19 +486,24 @@ export default class Site {
   #urlPage(page) {
     const { dest } = page;
     let url = page.data.url;
-    let transform = true;
 
     if (typeof url === "function") {
       url = url(page);
     }
 
-    if (typeof url === "object") {
-      dest.path = url.path || dest.path;
-      dest.ext = url.ext || "";
-      transform = false;
-    } else if (typeof url === "string") {
-      dest.ext = extname(url);
-      dest.path = dest.ext ? url.slice(0, -dest.ext.length) : url;
+    if (typeof url === "string") {
+      if (url.endsWith("/")) {
+        dest.path = posix.join(url, "index");
+        dest.ext = ".html";
+      } else {
+        dest.ext = extname(url);
+        dest.path = dest.ext ? url.slice(0, -dest.ext.length) : url;
+      }
+    } else if (!dest.ext) {
+      if (this.options.prettyUrls && posix.basename(dest.path) !== "index") {
+        dest.path = posix.join(dest.path, "index");
+      }
+      dest.ext = ".html";
     }
 
     // Relative URL
@@ -508,18 +513,8 @@ export default class Site {
       dest.path = `/${dest.path}`;
     }
 
-    // Transform (prettyUrls, slugifyUrls)
-    if (transform) {
-      if (this.options.slugifyUrls) {
-        dest.path = slugify(dest.path, this.options.slugifyUrls);
-      }
-
-      if (!dest.ext) {
-        if (this.options.prettyUrls && posix.basename(dest.path) !== "index") {
-          dest.path = posix.join(dest.path, "index");
-        }
-        dest.ext = ".html";
-      }
+    if (this.options.slugifyUrls) {
+      dest.path = slugify(dest.path, this.options.slugifyUrls);
     }
 
     page.data.url =

--- a/site.js
+++ b/site.js
@@ -491,6 +491,22 @@ export default class Site {
       url = url(page);
     }
 
+    let { prettyUrls, slugifyUrls } = this.options;
+
+    if (typeof url === "object") {
+      if (url.hasOwnProperty("pretty")) {
+        prettyUrls = url.pretty;
+      }
+
+      if (url.hasOwnProperty("slugify")) {
+        slugifyUrls = url.slugify;
+      }
+
+      if (url.hasOwnProperty("path")) {
+        url = url.path;
+      }
+    }
+
     if (typeof url === "string") {
       if (url.endsWith("/")) {
         dest.path = posix.join(url, "index");
@@ -500,7 +516,7 @@ export default class Site {
         dest.path = dest.ext ? url.slice(0, -dest.ext.length) : url;
       }
     } else if (!dest.ext) {
-      if (this.options.prettyUrls && posix.basename(dest.path) !== "index") {
+      if (prettyUrls && posix.basename(dest.path) !== "index") {
         dest.path = posix.join(dest.path, "index");
       }
       dest.ext = ".html";
@@ -513,8 +529,8 @@ export default class Site {
       dest.path = `/${dest.path}`;
     }
 
-    if (this.options.slugifyUrls) {
-      dest.path = slugify(dest.path, this.options.slugifyUrls);
+    if (slugifyUrls) {
+      dest.path = slugify(dest.path, slugifyUrls);
     }
 
     page.data.url =


### PR DESCRIPTION
@valtlai After a second thought, I've changed my mind about the possibility to define an url as an object and your idea of using the trailing slash to detect if the url is a pretty-html or a extension-less filename is better.

One of my goals with lume is building something easy to use and with predictable behavior, and the url variable that accepts so many formats (function, string, object) and different behaviors is far from being that.

With this change, the url can be defined using a function or a string:

- `/about-me` Generates a `/about-me` file (without extension)
- `/about-me/` Generates a `/about-me/index.html` file
- `/about-me.html` Generates a `/about-me.html` file

`prettyUrls` setting is used only if the page has not the url variable. `slugifyUrls` is used everywhere.
