### PR TITLE
Add `postcss` and `terser` filters

### DIFF
--- a/plugins/postcss.js
+++ b/plugins/postcss.js
@@ -37,6 +37,7 @@ export default function (userOptions = {}) {
 
     site.loadAssets(options.extensions, textLoader);
     site.process(options.extensions, processor);
+    site.filter("postcss", filter, true);
 
     async function processor(page) {
       const from = site.src(page.src.path + page.src.ext);
@@ -54,6 +55,11 @@ export default function (userOptions = {}) {
         mapFile.dest.ext = ".css.map";
         site.pages.push(mapFile);
       }
+    }
+
+    async function filter(code) {
+      const result = await runner.process(code, { from: undefined });
+      return result.css;
     }
   };
 }

--- a/plugins/terser.js
+++ b/plugins/terser.js
@@ -20,13 +20,14 @@ export default function (userOptions = {}) {
   return (site) => {
     site.loadAssets(options.extensions, textLoader);
     site.process(options.extensions, processor);
+    site.filter("terser", filter, true);
+
+    // Options passed to terser
+    const terserOptions = { ...options.options };
 
     async function processor(file) {
       const content = file.content;
       const filename = file.dest.path + file.dest.ext;
-
-      // Options passed to terser
-      const terserOptions = { ...options.options };
 
       if (options.sourceMap) {
         terserOptions.sourceMap = {
@@ -49,6 +50,11 @@ export default function (userOptions = {}) {
       } catch (err) {
         error("terser", `Error in file ${filename}`, err);
       }
+    }
+
+    async function filter(code) {
+      const output = await minify(code, terserOptions);
+      return output.code;
     }
   };
 }


### PR DESCRIPTION
This adds the `postcss` and `terser` filters to the corresponding plugins.

Using them:

```njk
{% set css %}
  body::after {
    content: "Hello, the CSS world!";
  }
{% endset %}

{% set js %}
  console.log("Hello, the JavaScript world!");
{% endset %}

<style>
  {{- css | postcss | safe -}}
</style>

<script type="module">
  {{- js | terser | safe -}}
</script>
```

@oscarotero What do you think?