### PR TITLE
relative_urls should ignore data URLs

### DIFF
--- a/plugins/relative_urls.js
+++ b/plugins/relative_urls.js
@@ -69,5 +69,6 @@ function ignore(url) {
     url.startsWith("../") ||
     url.startsWith("#") ||
     url.startsWith("?") ||
+    url.startsWith("data:") ||
     url.includes("//");
 }


### PR DESCRIPTION
Data URLs don't have `//`, so they are not caught by that rule.