### PR TITLE
Allow extensions on Nunjucks

### DIFF
--- a/plugins/nunjucks.js
+++ b/plugins/nunjucks.js
@@ -14,6 +14,11 @@ export default function (userOptions) {
   return (site) => {
     const nunjucksEngine = new NunjucksEngine(site, options.options);
 
+    const nunjucksExtensions = options.options.extensions ?? {};
+    for (const name of Object.keys(nunjucksExtensions)) {
+      nunjucksEngine.engine.addExtension(name, nunjucksExtensions[name]);
+    }
+
     site.loadPages(options.extensions, loader, nunjucksEngine);
     site.filter("njk", filter, true);
 

--- a/plugins/nunjucks.js
+++ b/plugins/nunjucks.js
@@ -6,6 +6,7 @@ import { merge } from "../utils.js";
 const defaults = {
   extensions: [".njk"],
   options: {},
+  plugins: {},
 };
 
 export default function (userOptions) {
@@ -14,9 +15,8 @@ export default function (userOptions) {
   return (site) => {
     const nunjucksEngine = new NunjucksEngine(site, options.options);
 
-    const nunjucksExtensions = options.options.extensions ?? {};
-    for (const name of Object.keys(nunjucksExtensions)) {
-      nunjucksEngine.engine.addExtension(name, nunjucksExtensions[name]);
+    for (const name of Object.keys(options.plugins)) {
+      nunjucksEngine.engine.addExtension(name, options.plugins[name]);
     }
 
     site.loadPages(options.extensions, loader, nunjucksEngine);


### PR DESCRIPTION
Extensions on Nunjucks can't be passed by regular options, they need to be added by `addExtension`, so we add a new `extensions` option and register them.

I had to move it inside the passed options, because `options.extensions` is already a thing. We could do `options.nunjucks_extensions` if you want it to be outside `options.options`. WDYT?