### PR TITLE
Allow setting includes directory and non-absolute copy

### DIFF
--- a/cli/build.js
+++ b/cli/build.js
@@ -115,7 +115,7 @@ export async function run(args) {
       }
 
       event.paths.forEach((path) =>
-        changes.add(join("/", relative(site.src(), path)))
+        changes.add(join("./", relative(site.src(), path)))
       );
 
       // Debounce

--- a/cli/build.js
+++ b/cli/build.js
@@ -87,7 +87,8 @@ export async function run(args) {
       await server(site);
     }
 
-    const watcher = Deno.watchFs(site.src());
+    const sources = [...site.source.staticFiles].map(x => site.src(x[0]));
+    const watcher = Deno.watchFs([site.src(), ...sources]);
     const changes = new Set();
     console.log("Watching for changes...");
 

--- a/engines/eta.js
+++ b/engines/eta.js
@@ -9,7 +9,7 @@ export default class Eta extends TemplateEngine {
     super(site, options);
 
     eta.configure({
-      views: site.src("_includes"),
+      views: site.src(site.options.includes),
       useWith: true,
     });
 

--- a/engines/nunjucks.js
+++ b/engines/nunjucks.js
@@ -7,7 +7,8 @@ export default class Nunjucks extends TemplateEngine {
   constructor(site, options) {
     super(site, options);
 
-    const loader = new nunjucks.FileSystemLoader(site.src("_includes"));
+    const loader = new nunjucks.FileSystemLoader(
+      site.src(site.options.includes));
     this.engine = new nunjucks.Environment(loader, options);
 
     // Update cache

--- a/engines/pug.js
+++ b/engines/pug.js
@@ -7,7 +7,7 @@ export default class Pug extends TemplateEngine {
 
   constructor(site, options = {}) {
     super(site, options);
-    this.includes = site.src("_includes");
+    this.includes = site.src(site.options.includes);
 
     // Update cache
     site.addEventListener("beforeUpdate", () => this.cache.clear());

--- a/plugins/postcss.js
+++ b/plugins/postcss.js
@@ -21,7 +21,7 @@ export default function (userOptions = {}) {
   return (site) => {
     const options = merge({
       ...defaults,
-      includes: site.src("_includes"),
+      includes: site.src(site.options.includes),
     }, userOptions);
 
     const plugins = [...options.plugins];

--- a/site.js
+++ b/site.js
@@ -220,7 +220,7 @@ export default class Site {
    * Copy static files or directories without processing
    */
   copy(from, to = from) {
-    this.source.staticFiles.set(join(from), join("/", to));
+    this.source.staticFiles.set(join("./", from), join("/", to));
     return this;
   }
 

--- a/site.js
+++ b/site.js
@@ -18,6 +18,7 @@ const defaults = {
   cwd: Deno.cwd(),
   src: "./",
   dest: "./_site",
+  includes: "_includes",
   dev: false,
   metrics: false,
   prettyUrls: true,
@@ -219,7 +220,7 @@ export default class Site {
    * Copy static files or directories without processing
    */
   copy(from, to = from) {
-    this.source.staticFiles.set(join("/", from), join("/", to));
+    this.source.staticFiles.set(join(from), join("/", to));
     return this;
   }
 
@@ -598,7 +599,7 @@ export default class Site {
         );
       }
 
-      const layoutPath = this.src("_includes", layout);
+      const layoutPath = this.src(this.options.includes, layout);
       const layoutData = await this.source.load(layoutPath, result[1]);
       const engine = this.#getEngine(layout, layoutData.templateEngine);
 


### PR DESCRIPTION
This PR adds a `includes` option to change the `_includes` directory and allows `site.copy()` to copy from directories relative to `src` (dest is still absolute).

The rationale behind this is: for one of my projects, I have loads of top level files, I want to keep them in a subdirectory. When I change `src`, I'm kinda forced to change my assets and _include, because they "follow" the src. With this change, I'm able to specify `includes: "../_includes"` and `site.copy('../assets', 'assets')`.

Alternatively, we could make those two (includes and copy) to be relative to the execution, but I'm not sure that's a good idea, because it breaks the "I want to isolate a build" use case.