### PR TITLE
Make includes directory configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 - Render pages in parallel, reducing the build time for large sites.
 - Made the `_includes` directory configurable: [#115]
-  - new site option `includes`
+  - new `includes` option for site and the `eta`, `nunjucks` and `pug` plugins.
   - new `site.includes()` method, similar to `site.src()`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Render pages in parallel, reducing the build time for large sites.
+- Made the `_includes` directory configurable: [#115]
+  - new site option `includes`
+  - new `site.includes()` method, similar to `site.src()`.
 
 ### Fixed
 - The async cache for the `inline` plugin.
@@ -919,6 +922,7 @@ The first version.
 [#109]: https://github.com/lumeland/lume/issues/109
 [#110]: https://github.com/lumeland/lume/issues/110
 [#114]: https://github.com/lumeland/lume/issues/114
+[#115]: https://github.com/lumeland/lume/issues/115
 
 [Unreleased]: https://github.com/lumeland/lume/compare/v0.23.3...HEAD
 [0.23.3]: https://github.com/lumeland/lume/compare/v0.23.2...v0.23.3

--- a/engines/eta.js
+++ b/engines/eta.js
@@ -1,33 +1,20 @@
-import * as eta from "../deps/eta.js";
-
 import TemplateEngine from "./template_engine.js";
 
 export default class Eta extends TemplateEngine {
   filters = {};
 
-  constructor(site, options = {}) {
-    super(site, options);
-
-    eta.configure({
-      views: site.includes(),
-      useWith: true,
-    });
-
-    // Update cache
-    site.addEventListener("beforeUpdate", (ev) => {
-      for (const filename of ev.files) {
-        eta.templates.remove(site.src(filename));
-      }
-    });
+  constructor(site, engine) {
+    super(site);
+    this.engine = engine;
   }
 
   async render(content, data, filename) {
-    if (!eta.templates.get(filename)) {
-      eta.templates.define(filename, eta.compile(content));
+    if (!this.engine.templates.get(filename)) {
+      this.engine.templates.define(filename, this.engine.compile(content));
     }
     data.filters = this.filters;
-    const fn = eta.templates.get(filename);
-    return await fn(data, eta.config);
+    const fn = this.engine.templates.get(filename);
+    return await fn(data, this.engine.config);
   }
 
   addHelper(name, fn, options) {
@@ -36,7 +23,7 @@ export default class Eta extends TemplateEngine {
         this.filters[name] = fn;
 
         if (options.async) {
-          eta.configure({ async: true });
+          this.engine.configure({ async: true });
         }
         return;
     }

--- a/engines/eta.js
+++ b/engines/eta.js
@@ -9,7 +9,7 @@ export default class Eta extends TemplateEngine {
     super(site, options);
 
     eta.configure({
-      views: site.src("_includes"),
+      views: site.includes(),
       useWith: true,
     });
 

--- a/engines/markdown.js
+++ b/engines/markdown.js
@@ -1,8 +1,8 @@
 import TemplateEngine from "./template_engine.js";
 
 export default class Markdown extends TemplateEngine {
-  constructor(site, engine, options = {}) {
-    super(site, options);
+  constructor(site, engine) {
+    super(site);
     this.engine = engine;
   }
 

--- a/engines/nunjucks.js
+++ b/engines/nunjucks.js
@@ -4,24 +4,14 @@ import TemplateEngine from "./template_engine.js";
 export default class Nunjucks extends TemplateEngine {
   cache = new Map();
 
-  constructor(site, options) {
+  constructor(site, engine) {
     super(site);
+    this.engine = engine;
 
-    const loader = new nunjucks.FileSystemLoader(site.includes());
-    this.engine = new nunjucks.Environment(loader, options);
-
-    // Update cache
+    // Update internal cache
     site.addEventListener("beforeUpdate", (ev) => {
       for (const file of ev.files) {
-        const filename = site.src(file);
-        const name = loader.pathsToNames[filename];
-
-        if (name) {
-          delete loader.cache[name];
-          continue;
-        }
-
-        this.cache.delete(filename);
+        this.cache.delete(site.src(file));
       }
     });
   }

--- a/engines/nunjucks.js
+++ b/engines/nunjucks.js
@@ -7,7 +7,7 @@ export default class Nunjucks extends TemplateEngine {
   constructor(site, options) {
     super(site, options);
 
-    const loader = new nunjucks.FileSystemLoader(site.src("_includes"));
+    const loader = new nunjucks.FileSystemLoader(site.includes());
     this.engine = new nunjucks.Environment(loader, options);
 
     // Update cache

--- a/engines/nunjucks.js
+++ b/engines/nunjucks.js
@@ -5,7 +5,7 @@ export default class Nunjucks extends TemplateEngine {
   cache = new Map();
 
   constructor(site, options) {
-    super(site, options);
+    super(site);
 
     const loader = new nunjucks.FileSystemLoader(site.includes());
     this.engine = new nunjucks.Environment(loader, options);

--- a/engines/pug.js
+++ b/engines/pug.js
@@ -1,12 +1,12 @@
-import * as pug from "../deps/pug.js";
 import TemplateEngine from "./template_engine.js";
 
 export default class Pug extends TemplateEngine {
   cache = new Map();
   filters = {};
 
-  constructor(site, options = {}) {
-    super(site, options);
+  constructor(site, engine) {
+    super(site);
+    this.engine = engine;
     this.includes = site.includes();
 
     // Update cache
@@ -17,7 +17,7 @@ export default class Pug extends TemplateEngine {
     if (!this.cache.has(filename)) {
       this.cache.set(
         filename,
-        pug.compile(content, {
+        this.engine.compile(content, {
           filename,
           basedir: this.includes,
           filters: this.filters,

--- a/engines/pug.js
+++ b/engines/pug.js
@@ -2,12 +2,11 @@ import TemplateEngine from "./template_engine.js";
 
 export default class Pug extends TemplateEngine {
   cache = new Map();
-  filters = {};
 
-  constructor(site, engine, basedir) {
+  constructor(site, engine, options) {
     super(site);
     this.engine = engine;
-    this.basedir = basedir;
+    this.options = options;
 
     // Update cache
     site.addEventListener("beforeUpdate", () => this.cache.clear());
@@ -18,9 +17,8 @@ export default class Pug extends TemplateEngine {
       this.cache.set(
         filename,
         this.engine.compile(content, {
+          ...this.options,
           filename,
-          basedir: this.basedir,
-          filters: this.filters,
         }),
       );
     }
@@ -31,7 +29,8 @@ export default class Pug extends TemplateEngine {
   addHelper(name, fn, options) {
     switch (options.type) {
       case "filter":
-        this.filters[name] = (text, opt) => {
+        this.options.filters ||= {};
+        this.options.filters[name] = (text, opt) => {
           delete opt.filename;
           const args = Object.values(opt);
           return fn(text, ...args);

--- a/engines/pug.js
+++ b/engines/pug.js
@@ -7,7 +7,7 @@ export default class Pug extends TemplateEngine {
 
   constructor(site, options = {}) {
     super(site, options);
-    this.includes = site.src("_includes");
+    this.includes = site.includes();
 
     // Update cache
     site.addEventListener("beforeUpdate", () => this.cache.clear());

--- a/engines/pug.js
+++ b/engines/pug.js
@@ -4,10 +4,10 @@ export default class Pug extends TemplateEngine {
   cache = new Map();
   filters = {};
 
-  constructor(site, engine) {
+  constructor(site, engine, basedir) {
     super(site);
     this.engine = engine;
-    this.includes = site.includes();
+    this.basedir = basedir;
 
     // Update cache
     site.addEventListener("beforeUpdate", () => this.cache.clear());
@@ -19,7 +19,7 @@ export default class Pug extends TemplateEngine {
         filename,
         this.engine.compile(content, {
           filename,
-          basedir: this.includes,
+          basedir: this.basedir,
           filters: this.filters,
         }),
       );

--- a/engines/template_engine.js
+++ b/engines/template_engine.js
@@ -1,7 +1,6 @@
 export default class TemplateEngine {
-  constructor(site, options = {}) {
+  constructor(site) {
     this.site = site;
-    this.options = options;
   }
 
   render(_content, _data, _filename) {

--- a/plugins/eta.js
+++ b/plugins/eta.js
@@ -6,15 +6,19 @@ import { merge } from "../utils.js";
 // Default options
 const defaults = {
   extensions: [".eta"],
+  includes: null,
 };
 
 export default function (userOptions) {
-  const options = merge(defaults, userOptions);
-
   return (site) => {
+    const options = merge(
+      { ...defaults, includes: site.includes() },
+      userOptions,
+    );
+
     // Configure eta
     eta.configure({
-      views: site.includes(),
+      views: options.includes,
       useWith: true,
     });
 

--- a/plugins/eta.js
+++ b/plugins/eta.js
@@ -1,3 +1,4 @@
+import * as eta from "../deps/eta.js";
 import Eta from "../engines/eta.js";
 import loader from "../loaders/text.js";
 import { merge } from "../utils.js";
@@ -11,8 +12,20 @@ export default function (userOptions) {
   const options = merge(defaults, userOptions);
 
   return (site) => {
-    const eta = new Eta(site);
+    // Configure eta
+    eta.configure({
+      views: site.includes(),
+      useWith: true,
+    });
 
-    site.loadPages(options.extensions, loader, eta);
+    // Update cache
+    site.addEventListener("beforeUpdate", (ev) => {
+      for (const filename of ev.files) {
+        eta.templates.remove(site.src(filename));
+      }
+    });
+
+    // Load pages
+    site.loadPages(options.extensions, loader, new Eta(site, eta));
   };
 }

--- a/plugins/nunjucks.js
+++ b/plugins/nunjucks.js
@@ -1,3 +1,4 @@
+import nunjucks from "../deps/nunjucks.js";
 import NunjucksEngine from "../engines/nunjucks.js";
 import loader from "../loaders/text.js";
 import { merge } from "../utils.js";
@@ -13,18 +14,37 @@ export default function (userOptions) {
   const options = merge(defaults, userOptions);
 
   return (site) => {
-    const nunjucksEngine = new NunjucksEngine(site, options.options);
+    // Create the nunjucks environment instance
+    const fsLoader = new nunjucks.FileSystemLoader(site.includes());
+    const engine = new nunjucks.Environment(fsLoader, options.options);
 
     for (const [name, fn] of Object.entries(options.plugins)) {
-      nunjucksEngine.engine.addExtension(name, fn);
+      engine.addExtension(name, fn);
     }
 
-    site.loadPages(options.extensions, loader, nunjucksEngine);
+    // Update cache
+    site.addEventListener("beforeUpdate", (ev) => {
+      for (const file of ev.files) {
+        const filename = site.src(file);
+        const name = loader.pathsToNames[filename];
+
+        if (name) {
+          delete loader.cache[name];
+          continue;
+        }
+      }
+    });
+
+    site.loadPages(
+      options.extensions,
+      loader,
+      new NunjucksEngine(site, engine),
+    );
     site.filter("njk", filter, true);
 
     function filter(string, data = {}) {
       return new Promise((resolve, reject) => {
-        nunjucksEngine.engine.renderString(string, data, (err, result) => {
+        engine.renderString(string, data, (err, result) => {
           if (err) {
             reject(err);
           } else {

--- a/plugins/nunjucks.js
+++ b/plugins/nunjucks.js
@@ -6,16 +6,20 @@ import { merge } from "../utils.js";
 // Default options
 const defaults = {
   extensions: [".njk"],
+  includes: null,
   options: {},
   plugins: {},
 };
 
 export default function (userOptions) {
-  const options = merge(defaults, userOptions);
-
   return (site) => {
+    const options = merge(
+      { ...defaults, includes: site.includes() },
+      userOptions,
+    );
+
     // Create the nunjucks environment instance
-    const fsLoader = new nunjucks.FileSystemLoader(site.includes());
+    const fsLoader = new nunjucks.FileSystemLoader(options.includes);
     const engine = new nunjucks.Environment(fsLoader, options.options);
 
     for (const [name, fn] of Object.entries(options.plugins)) {

--- a/plugins/postcss.js
+++ b/plugins/postcss.js
@@ -21,7 +21,7 @@ export default function (userOptions = {}) {
   return (site) => {
     const options = merge({
       ...defaults,
-      includes: site.src("_includes"),
+      includes: site.includes(),
     }, userOptions);
 
     const plugins = [...options.plugins];

--- a/plugins/postcss.js
+++ b/plugins/postcss.js
@@ -19,10 +19,10 @@ const defaults = {
 
 export default function (userOptions = {}) {
   return (site) => {
-    const options = merge({
-      ...defaults,
-      includes: site.includes(),
-    }, userOptions);
+    const options = merge(
+      { ...defaults, includes: site.includes() },
+      userOptions,
+    );
 
     const plugins = [...options.plugins];
 

--- a/plugins/pug.js
+++ b/plugins/pug.js
@@ -6,12 +6,16 @@ import { merge } from "../utils.js";
 // Default options
 const defaults = {
   extensions: [".pug"],
+  includes: null,
 };
 
 export default function (userOptions) {
-  const options = merge(defaults, userOptions);
-
   return (site) => {
+    const options = merge(
+      { ...defaults, includes: site.includes() },
+      userOptions,
+    );
+
     site.loadPages(options.extensions, loader, new Pug(site, pug));
   };
 }

--- a/plugins/pug.js
+++ b/plugins/pug.js
@@ -7,6 +7,7 @@ import { merge } from "../utils.js";
 const defaults = {
   extensions: [".pug"],
   includes: null,
+  options: {},
 };
 
 export default function (userOptions) {
@@ -16,10 +17,12 @@ export default function (userOptions) {
       userOptions,
     );
 
+    options.options.basedir = options.includes;
+
     site.loadPages(
       options.extensions,
       loader,
-      new Pug(site, pug, options.includes),
+      new Pug(site, pug, options),
     );
   };
 }

--- a/plugins/pug.js
+++ b/plugins/pug.js
@@ -16,6 +16,10 @@ export default function (userOptions) {
       userOptions,
     );
 
-    site.loadPages(options.extensions, loader, new Pug(site, pug));
+    site.loadPages(
+      options.extensions,
+      loader,
+      new Pug(site, pug, options.includes),
+    );
   };
 }

--- a/plugins/pug.js
+++ b/plugins/pug.js
@@ -22,7 +22,7 @@ export default function (userOptions) {
     site.loadPages(
       options.extensions,
       loader,
-      new Pug(site, pug, options),
+      new Pug(site, pug, options.options),
     );
   };
 }

--- a/plugins/pug.js
+++ b/plugins/pug.js
@@ -1,3 +1,4 @@
+import * as pug from "../deps/pug.js";
 import Pug from "../engines/pug.js";
 import loader from "../loaders/text.js";
 import { merge } from "../utils.js";
@@ -11,8 +12,6 @@ export default function (userOptions) {
   const options = merge(defaults, userOptions);
 
   return (site) => {
-    const pug = new Pug(site);
-
-    site.loadPages(options.extensions, loader, pug);
+    site.loadPages(options.extensions, loader, new Pug(site, pug));
   };
 }

--- a/site.js
+++ b/site.js
@@ -18,6 +18,7 @@ const defaults = {
   cwd: Deno.cwd(),
   src: "./",
   dest: "./_site",
+  includes: "_includes",
   dev: false,
   metrics: false,
   prettyUrls: true,
@@ -65,6 +66,13 @@ export default class Site {
    */
   dest(...path) {
     return join(this.options.cwd, this.options.dest, ...path);
+  }
+
+  /**
+   * Returns the includes path
+   */
+  includes(...path) {
+    return this.src(this.options.includes, ...path);
   }
 
   /**
@@ -598,7 +606,7 @@ export default class Site {
         );
       }
 
-      const layoutPath = this.src("_includes", layout);
+      const layoutPath = this.includes(layout);
       const layoutData = await this.source.load(layoutPath, result[1]);
       const engine = this.#getEngine(layout, layoutData.templateEngine);
 


### PR DESCRIPTION
This implements the possibility of configuring the includes directory proposed in #111:

- <del>Adds a new `--includes` CLI option.</del>
- Adds `site.options.includes`.
- Adds `site.includes()`, similar to `site.src()`.
- Replaces the hard coded include paths with `site.includes()`.

@oscarotero, what do you think? Do we need this?

We should also decide what should happen if the specified includes directory doesn’t start with `_` (or `.`). Should we throw an error or just ignore the directory (like `site.ignore(site.includes())`)?