### PR TITLE
use fsLoader on nunjucks

### DIFF
--- a/plugins/nunjucks.js
+++ b/plugins/nunjucks.js
@@ -30,10 +30,10 @@ export default function (userOptions) {
     site.addEventListener("beforeUpdate", (ev) => {
       for (const file of ev.files) {
         const filename = site.src(file);
-        const name = loader.pathsToNames[filename];
+        const name = fsLoader.pathsToNames[filename];
 
         if (name) {
-          delete loader.cache[name];
+          delete fsLoader.cache[name];
           continue;
         }
       }


### PR DESCRIPTION
[this commit](https://github.com/lumeland/lume/commit/e96f2e1f9266e9b3cf4ccc12d636aafbb28e186e) breaks update on nunjucks, because there are two `loader` on the original one that got mixed up.