### PR TITLE
Track files' dependencies when watching filesystem

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -26,6 +26,9 @@ export interface Data {
   /** To configure a different template engine(s) to render a page */
   templateEngine?: string | string[];
 
+  /** Dependencies to watch for this page */
+  dependencies?: string[];
+
   [index: string]: unknown;
 }
 

--- a/core/loaders/module.ts
+++ b/core/loaders/module.ts
@@ -1,11 +1,22 @@
 import { Data } from "../../core.ts";
 import { isPlainObject } from "../utils.ts";
 
-/** Load a JavaScript/TypeScript file. Use a random hash to prevent caching */
+const bundle = "deno:///bundle.js";
+const fileProtocol = "file://";
+
+interface SourceMap {
+  version: number;
+  sources: string[];
+  names: unknown[];
+  mappings: string;
+}
+
+/** Load a JavaScript/TypeScript file. Use a Deno.emit to prevent caching */
 export default async function (path: string): Promise<Data> {
-  const hash = Date.now();
-  const mod = await import(`file://${path}#${hash}`);
-  const data: Data = {};
+  const result = await Deno.emit(path, { bundle: "module" });
+  const deps = getDependencies(path, result);
+  const mod = await executeModule(result);
+  const data: Data = { dependencies: deps };
 
   for (const [name, value] of Object.entries(mod)) {
     if (name === "default") {
@@ -21,4 +32,20 @@ export default async function (path: string): Promise<Data> {
   }
 
   return data;
+}
+
+function getDependencies(path: string, result: Deno.EmitResult) {
+  const { sources } = JSON.parse(result.files[`${bundle}.map`]) as SourceMap;
+  const filePath = `${fileProtocol}${path}`;
+
+  return sources
+    .filter((x) => x !== filePath && x.startsWith(fileProtocol))
+    .map((x) => x.substr(fileProtocol.length));
+}
+
+function executeModule(result: Deno.EmitResult) {
+  const code = result.files[bundle] as string;
+  const metadata = "data:application/javascript;charset=utf-8";
+  const encoded = `${metadata},${encodeURIComponent(code)}`;
+  return import(encoded);
 }

--- a/tests/loaders.test.ts
+++ b/tests/loaders.test.ts
@@ -35,7 +35,7 @@ Deno.test("load the pages of a site", async () => {
     // @ts-ignore: unknown property
     equals(page.data.colors.length, 3);
     // @ts-ignore: unknown property
-    equals(page.data.documents.length, 3);
+    equals(page.data.documents.content.length, 3);
     // @ts-ignore: unknown property
     equals(page.data.drinks.alcoholic.length, 2);
     // @ts-ignore: unknown property


### PR DESCRIPTION
This is implemented by changing `loader/module.ts`, adding a step before the module to be loaded is actually evaluated. We use `Deno.emit()` to bundle the module with all it's dependencies, this way Deno cache will be bypased and we'll always load the latest version from disk.

`Deno.emit()` also returns source maps for the generated bundle. We use this information to extract the dependencies of the module, this way when we detect one of such dependencies has changed we know we need to also load the dependant module.