### PR TITLE
Allow passing sourceMap options to PostCSS

### DIFF
--- a/deps/postcss.d.ts
+++ b/deps/postcss.d.ts
@@ -1,1 +1,0 @@
-import { SourceMapOptions } from "https://deno.land/x/postcss@8.3.11/lib/postcss.d.ts";

--- a/deps/postcss.d.ts
+++ b/deps/postcss.d.ts
@@ -1,0 +1,1 @@
+import { SourceMapOptions } from "https://deno.land/x/postcss@8.3.11/lib/postcss.d.ts";

--- a/deps/postcss.ts
+++ b/deps/postcss.ts
@@ -7,7 +7,7 @@ export interface SourceMapOptions {
   inline?: boolean
   prev?: string | boolean | object | ((file: string) => string)
   sourcesContent?: boolean
-  annotation?: string | boolean | ((file: string, root: Root) => string)
+  annotation?: string | boolean | ((file: string, root: any) => string)
   from?: string
   absolute?: boolean
 }

--- a/deps/postcss.ts
+++ b/deps/postcss.ts
@@ -2,4 +2,3 @@ export { default as postcss } from "https://deno.land/x/postcss@8.3.11/mod.js";
 export { default as postcssImport } from "https://deno.land/x/postcss_import@0.1.4/mod.js";
 export { default as postcssNesting } from "https://cdn.jsdelivr.net/gh/csstools/postcss-nesting@9.0.0/mod.js";
 export { default as autoprefixer } from "https://deno.land/x/postcss_autoprefixer@0.1.1/mod.js";
-export { SourceMapOptions } from "https://deno.land/x/postcss@8.3.11/lib/postcss.d.ts";

--- a/deps/postcss.ts
+++ b/deps/postcss.ts
@@ -2,3 +2,4 @@ export { default as postcss } from "https://deno.land/x/postcss@8.3.11/mod.js";
 export { default as postcssImport } from "https://deno.land/x/postcss_import@0.1.4/mod.js";
 export { default as postcssNesting } from "https://cdn.jsdelivr.net/gh/csstools/postcss-nesting@9.0.0/mod.js";
 export { default as autoprefixer } from "https://deno.land/x/postcss_autoprefixer@0.1.1/mod.js";
+export type { SourceMapOptions } from "https://deno.land/x/postcss@8.3.11/lib/postcss.d.ts";

--- a/deps/postcss.ts
+++ b/deps/postcss.ts
@@ -2,3 +2,12 @@ export { default as postcss } from "https://deno.land/x/postcss@8.3.11/mod.js";
 export { default as postcssImport } from "https://deno.land/x/postcss_import@0.1.4/mod.js";
 export { default as postcssNesting } from "https://cdn.jsdelivr.net/gh/csstools/postcss-nesting@9.0.0/mod.js";
 export { default as autoprefixer } from "https://deno.land/x/postcss_autoprefixer@0.1.1/mod.js";
+
+export interface SourceMapOptions {
+  inline?: boolean
+  prev?: string | boolean | object | ((file: string) => string)
+  sourcesContent?: boolean
+  annotation?: string | boolean | ((file: string, root: Root) => string)
+  from?: string
+  absolute?: boolean
+}

--- a/deps/postcss.ts
+++ b/deps/postcss.ts
@@ -2,12 +2,4 @@ export { default as postcss } from "https://deno.land/x/postcss@8.3.11/mod.js";
 export { default as postcssImport } from "https://deno.land/x/postcss_import@0.1.4/mod.js";
 export { default as postcssNesting } from "https://cdn.jsdelivr.net/gh/csstools/postcss-nesting@9.0.0/mod.js";
 export { default as autoprefixer } from "https://deno.land/x/postcss_autoprefixer@0.1.1/mod.js";
-
-export interface SourceMapOptions {
-  inline?: boolean
-  prev?: string | boolean | object | ((file: string) => string)
-  sourcesContent?: boolean
-  annotation?: string | boolean | ((file: string, root: any) => string)
-  from?: string
-  absolute?: boolean
-}
+export { SourceMapOptions } from "https://deno.land/x/postcss@8.3.11/lib/postcss.d.ts";

--- a/plugins/postcss.ts
+++ b/plugins/postcss.ts
@@ -69,7 +69,7 @@ export default function (userOptions?: Partial<Options>) {
     async function postCss(file: Page) {
       const from = site.src(file.src.path + file.src.ext);
       const to = site.dest(file.dest.path + file.dest.ext);
-      const map = options.sourceMap ? { inline: false } : undefined;
+      const map = options.sourceMap;
 
       // Process the code with PostCSS
       const result = await runner.process(file.content!, { from, to, map });

--- a/plugins/postcss.ts
+++ b/plugins/postcss.ts
@@ -3,6 +3,7 @@ import {
   postcss,
   postcssImport,
   postcssNesting,
+  SourceMapOptions,
 } from "../deps/postcss.ts";
 import { merge } from "../core/utils.ts";
 import { Helper, Page, Site } from "../core.ts";
@@ -13,7 +14,7 @@ export interface Options {
   extensions: string[];
 
   /** Set `true` to generate source map files */
-  sourceMap: boolean;
+  sourceMap: boolean | SourceMapOptions;
 
   /** Custom includes path for `postcss-import` */
   includes: string | string[] | false;


### PR DESCRIPTION
PostCSS accepts `boolean | SourceMapOptions` as `options.map`.
This slightly changes the default behavior, as "map: true" will default to inline.

We can change it to `options.sourceMap === true ? {inline: false} : options.sourceMap`, but I'm not sure is worth keeping the extra weirdness. WDYT?