### PR TITLE
Add option to configure filter names for url plugin

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -2,7 +2,7 @@ import { parse } from "./deps/flags.ts";
 import { resolve } from "./deps/path.ts";
 import Site from "./core/site.ts";
 
-import url from "./plugins/url.ts";
+import url, { Options as UrlOptions } from "./plugins/url.ts";
 import json, { Options as JsonOptions } from "./plugins/json.ts";
 import markdown, { Options as MarkdownOptions } from "./plugins/markdown.ts";
 import modules, { Options as ModulesOptions } from "./plugins/modules.ts";
@@ -15,6 +15,7 @@ import { merge } from "./core/utils.ts";
 import { ServerOptions, SiteOptions, WatcherOptions } from "./core.ts";
 
 interface PluginOptions {
+  url?: Partial<UrlOptions>;
   json?: Partial<JsonOptions>;
   markdown?: Partial<MarkdownOptions>;
   modules?: Partial<ModulesOptions>;
@@ -42,7 +43,7 @@ export default function (
 
   return site
     .ignore("node_modules")
-    .use(url())
+    .use(url(pluginOptions.url))
     .use(json(pluginOptions.json))
     .use(markdown(pluginOptions.markdown))
     .use(modules(pluginOptions.modules))

--- a/plugins/url.ts
+++ b/plugins/url.ts
@@ -1,13 +1,31 @@
 import { Helper, Site } from "../core.ts";
+import { merge } from "../core/utils.ts";
+
+export interface Options {
+  /** The url helper name */
+  names: {
+      url: string;
+      htmlUrl: string;
+  };
+}
+
+const defaults: Options = {
+  names: {
+      url: 'url',
+      htmlUrl: 'htmlUrl'
+  },
+};
 
 /**
  * A plugin to register the filters "url" and "htmlUrl"
  * for normalizing URLs in the templates
  */
-export default function () {
+export default function (userOptions?: Partial<Options>) {
+  const options = merge(defaults, userOptions);
+
   return (site: Site) => {
-    site.filter("url", url as Helper);
-    site.filter("htmlUrl", htmlUrl as Helper);
+    site.filter(options.names.url, url as Helper);
+    site.filter(options.names.htmlUrl, htmlUrl as Helper);
 
     function url(path = "/", absolute = false) {
       return typeof path === "string" ? site.url(path, absolute) : path;

--- a/tests/assets/url/default-filter.tmpl.js
+++ b/tests/assets/url/default-filter.tmpl.js
@@ -1,0 +1,17 @@
+export const title = "Default Filter";
+export const url = "/default-filter";
+
+export default function ({}, { url, htmlUrl }) {
+  return `
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <title>Default Filter</title>
+        </head>
+        <body>
+            <a id="url" href="${url?.("/url/", true)}">Url</a>
+            ${htmlUrl?.('<a id="htmlUrl" href="/htmlUrl/">htmlUrl</a>', true)}
+        </body>
+    </html>
+  `;
+}

--- a/tests/assets/url/renamed-filter.tmpl.js
+++ b/tests/assets/url/renamed-filter.tmpl.js
@@ -1,0 +1,17 @@
+export const title = "Renamed Filter";
+export const url = "/renamed-filter";
+
+export default function ({}, { urlify, htmlUrlify }) {
+  return `
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <title>Renamed Filter</title>
+        </head>
+        <body>
+            <a id="urlify" href="${urlify?.("/urlify/", true)}">Urlify</a>
+            ${htmlUrlify?.('<a id="htmlUrlify" href="/htmlUrlify/">htmlUrlify</a>', true)}
+        </body>
+    </html>
+  `;
+}

--- a/tests/url.test.ts
+++ b/tests/url.test.ts
@@ -1,0 +1,62 @@
+import { assertStrictEquals as equals } from "../deps/assert.ts";
+import { getSite, testPage } from "./utils.ts";
+import urlPlugin from "../plugins/url.ts";
+
+Deno.test("url and htmlUrl update href", async () => {
+  const site = getSite({
+    dev: true,
+    src: "url",
+    location: new URL("https://example.com/test/"),
+  });
+
+  site.use(urlPlugin({}));
+
+  await site.build();
+
+  testPage(site, "/default-filter", (page) => {
+    equals(
+      page.document?.querySelector("#url")?.getAttribute("href"),
+      "https://example.com/test/url/"
+    );
+  });
+
+  testPage(site, "/default-filter", (page) => {
+    equals(
+      page.document?.querySelector("#htmlUrl")?.getAttribute("href"),
+      "https://example.com/test/htmlUrl/"
+    );
+  });
+
+});
+
+Deno.test("configure url and htmlUrl names", async () => {
+  const site = getSite({
+    dev: true,
+    src: "url",
+    location: new URL("https://example.com/"),
+  });
+
+  site.use(urlPlugin({
+    names: {
+      url: 'urlify',
+      htmlUrl: 'htmlUrlify',
+    },
+  }));
+
+  await site.build();
+
+  testPage(site, "/renamed-filter", (page) => {
+    equals(
+      page.document?.querySelector("#urlify")?.getAttribute("href"),
+      "https://example.com/urlify/"
+    );
+  });
+
+  testPage(site, "/renamed-filter", (page) => {
+    equals(
+      page.document?.querySelector("#htmlUrlify")?.getAttribute("href"),
+      "https://example.com/htmlUrlify/"
+    );
+  });
+
+});

--- a/tests/url.test.ts
+++ b/tests/url.test.ts
@@ -1,6 +1,5 @@
 import { assertStrictEquals as equals } from "../deps/assert.ts";
 import { getSite, testPage } from "./utils.ts";
-import urlPlugin from "../plugins/url.ts";
 
 Deno.test("url and htmlUrl update href", async () => {
   const site = getSite({
@@ -8,8 +7,6 @@ Deno.test("url and htmlUrl update href", async () => {
     src: "url",
     location: new URL("https://example.com/test/"),
   });
-
-  site.use(urlPlugin({}));
 
   await site.build();
 
@@ -34,14 +31,14 @@ Deno.test("configure url and htmlUrl names", async () => {
     dev: true,
     src: "url",
     location: new URL("https://example.com/"),
-  });
-
-  site.use(urlPlugin({
-    names: {
-      url: 'urlify',
-      htmlUrl: 'htmlUrlify',
+  }, {
+    url: {
+      names: {
+        url: 'urlify',
+        htmlUrl: 'htmlUrlify',
+      },
     },
-  }));
+  });
 
   await site.build();
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -20,10 +20,10 @@ class TestEmitter implements Emitter {
 }
 
 /** Create a new lume site using the "assets" path as cwd */
-export function getSite(options: Partial<SiteOptions> = {}): Site {
+export function getSite(options: Partial<SiteOptions> = {}, pluginOptions?: any): Site {
   options.cwd = cwd;
 
-  const site = lume(options, {}, false);
+  const site = lume(options, pluginOptions, false);
   site.emitter = new TestEmitter();
 
   return site;


### PR DESCRIPTION
- Update url plugin to accept an option to configure `url` and `htmlUrl` filter names.
- Implement tests for default filter names and configured filter names including two test pages.
- I am unsure about the name for the options as no other plugin has two filter names. Other plugins could therefore use `name` as the property. I propose to use `options.names.filterDefaultName` as the pattern in this case. e.g. `options.names.url`