### PR TITLE
Add option to configure helper name for date plugin

### DIFF
--- a/plugins/date.ts
+++ b/plugins/date.ts
@@ -12,6 +12,10 @@ const formats = new Map([
 ]);
 
 export interface Options {
+
+  /** The name of the helper */
+  name: string;
+
   /** The loaded locales */
   locales: Record<string, unknown>;
 
@@ -21,6 +25,7 @@ export interface Options {
 
 // Default options
 const defaults: Options = {
+  name: "date",
   locales: {},
   formats: {},
 };
@@ -31,7 +36,7 @@ export default function (userOptions?: Partial<Options>) {
   const defaultLocale = Object.keys(options.locales).shift();
 
   return (site: Site) => {
-    site.filter("date", filter as Helper);
+    site.filter(options.name, filter as Helper);
 
     function filter(
       date: string | Date,

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -54,3 +54,16 @@ Deno.test("date plugin with custom locale", () => {
     "1 de janeiro de 1970 às 00:00:00 GMT+0",
   );
 });
+
+Deno.test("date plugin with custom name", () => {
+  const site = lume();
+  site.use(date({
+    name: "dateify",
+    locales: { gl, pt },
+  }));
+
+  const { helpers } = site.renderer as LumeRenderer;
+  const [format] = helpers.get("dateify")!;
+
+  equals(format(date0, "HUMAN_DATE"), "1 de xaneiro 1970");
+});


### PR DESCRIPTION
- Make date filter configurable via plugin option.
- Add test to check that date helper can be accessed with custom name.