### PR TITLE
fix: import maps does not work on local files

### DIFF
--- a/ci.ts
+++ b/ci.ts
@@ -1,5 +1,5 @@
 import { encode } from "./deps/base64.ts";
-import { posix } from "./deps/path.ts";
+import { posix, toFileUrl } from "./deps/path.ts";
 import { parse } from "./deps/flags.ts";
 import { brightGreen, red } from "./deps/colors.ts";
 import { Exception } from "./core/errors.ts";
@@ -34,7 +34,7 @@ async function ensureUrl(maybeUrl: string) {
   try {
     return new URL(maybeUrl);
   } catch {
-    return new URL("file:" + await Deno.realPath(maybeUrl));
+    return toFileUrl(await Deno.realPath(maybeUrl));
   }
 }
 

--- a/ci.ts
+++ b/ci.ts
@@ -30,6 +30,14 @@ export function checkDenoVersion(): void {
   }
 }
 
+async function ensureUrl(maybeUrl: string) {
+  try {
+    return new URL(maybeUrl);
+  } catch {
+    return new URL("file:" + await Deno.realPath(maybeUrl));
+  }
+}
+
 /**
  * Return a data url with the import map of Lume
  * Optionally merge it with a custom import map from the user
@@ -45,7 +53,8 @@ export async function getImportMap(mapFile?: string) {
 
   if (mapFile) {
     try {
-      const file = await (await fetch(mapFile)).text();
+      const url = await ensureUrl(mapFile);
+      const file = await (await fetch(url)).text();
       const parsedMap = JSON.parse(file) as ImportMap;
       map.imports = { ...map.imports, ...parsedMap.imports };
       map.scopes = parsedMap.scopes;


### PR DESCRIPTION
When you specify a local file as an import map, Lume raises an error even when the specified file is a valid import map.
```
$ lume --serve -- --import-map=./import_map.json
Error: Unable to load the import map file
- mapFile: ./import_map.json
    at getImportMap (https://deno.land/x/lume@v1.4.1/ci.ts:53:13)
    at async getArgs (https://deno.land/x/lume@v1.4.1/ci.ts:95:33)
    at async main (https://deno.land/x/lume@v1.4.1/ci.ts:103:32)
    at async (https://deno.land/x/lume@v1.4.1/cli.ts:150:5)

Caused by TypeError: Invalid URL
    at Object.opSync (deno:core/01_core.js:149:12)
    at opUrlParse (deno:ext/url/00_url.js:47:27)
    at new URL (deno:ext/url/00_url.js:320:20)
    at new Request (deno:ext/fetch/23_request.js:241:27)
    at (deno:ext/fetch/26_fetch.js:396:29)
    at fetch (deno:ext/fetch/26_fetch.js:392:12)
    at getImportMap (https://deno.land/x/lume@v1.4.1/ci.ts:48:33)
    at getArgs (https://deno.land/x/lume@v1.4.1/ci.ts:95:39)
    at main (https://deno.land/x/lume@v1.4.1/ci.ts:103:38)
```

This PR resolves this.