### PR TITLE
fix: Fails to load import map with module URL starting with "./"

### DIFF
--- a/ci.ts
+++ b/ci.ts
@@ -41,20 +41,20 @@ async function ensureUrl(maybeUrl: string) {
 }
 
 /**
- * If a given specifier map has a value which starts with "./",
- * resolve it with given base URL.
+ * If a given specifier map has relative paths,
+ * resolve them with a given base URL.
  */
 function resolveSpecifierMap(specifierMap: SpecifierMap, baseUrl: URL) {
   return Object.fromEntries(
     Object.entries(specifierMap).map((
       [key, value],
-    ) => [key, value.startsWith("./") ? new URL(value, baseUrl).href : value]),
+    ) => [key, new URL(value, baseUrl).href]),
   );
 }
 
 /**
- * If any specifier maps in the given import map has a value which starts with "./",
- * resolve it with given base URL.
+ * If any specifier maps in a given import map have relative paths,
+ * resolve it with a given base URL.
  */
 function resolveImportMap(importMap: ImportMap, baseUrl: URL) {
   const imports = resolveSpecifierMap(importMap.imports, baseUrl);

--- a/ci.ts
+++ b/ci.ts
@@ -7,9 +7,11 @@ import { Exception } from "./core/errors.ts";
 const { join } = posix;
 const baseUrl = new URL(".", import.meta.url).href;
 
+type SpecifierMap = Record<string, string>;
+
 interface ImportMap {
-  imports: Record<string, string>;
-  scopes?: Record<string, Record<string, string>>;
+  imports: SpecifierMap;
+  scopes?: Record<string, SpecifierMap>;
 }
 
 export function checkDenoVersion(): void {
@@ -39,6 +41,32 @@ async function ensureUrl(maybeUrl: string) {
 }
 
 /**
+ * If a given specifier map has a value which starts with "./",
+ * resolve it with given base URL.
+ */
+function resolveSpecifierMap(specifierMap: SpecifierMap, baseUrl: URL) {
+  return Object.fromEntries(
+    Object.entries(specifierMap).map((
+      [key, value],
+    ) => [key, value.startsWith("./") ? new URL(value, baseUrl).href : value]),
+  );
+}
+
+/**
+ * If any specifier maps in the given import map has a value which starts with "./",
+ * resolve it with given base URL.
+ */
+function resolveImportMap(importMap: ImportMap, baseUrl: URL) {
+  const imports = resolveSpecifierMap(importMap.imports, baseUrl);
+  const scopes = Object.fromEntries(
+    Object.entries(importMap.scopes ?? []).map((
+      [scopeSpecifier, specifierMap],
+    ) => [scopeSpecifier, resolveSpecifierMap(specifierMap, baseUrl)]),
+  );
+  return { imports, scopes };
+}
+
+/**
  * Return a data url with the import map of Lume
  * Optionally merge it with a custom import map from the user
  */
@@ -56,7 +84,8 @@ export async function getImportMap(mapFile?: string) {
       const url = await ensureUrl(mapFile);
       const file = await (await fetch(url)).text();
       const parsedMap = JSON.parse(file) as ImportMap;
-      map.imports = { ...map.imports, ...parsedMap.imports };
+      const resolvedMap = resolveImportMap(parsedMap, url);
+      map.imports = { ...map.imports, ...resolvedMap.imports };
       map.scopes = parsedMap.scopes;
     } catch (cause) {
       throw new Exception("Unable to load the import map file", {


### PR DESCRIPTION
Lume fails to parse import map like following:
```js
{
  "imports": {
    "/": "./"
}

// Import map diagnostics:
//   - Invalid address "./" for the specifier key "/".
```

This is because Lume parses the given import map and convert it to data URI scheme.
Data URI scheme has no base URL, so parsing this specifier [fails](https://wicg.github.io/import-maps/#parse-a-url-like-import-specifier).

https://github.com/lumeland/lume/blob/5f0d950bcf20458e431f05ed84762a12d8b6548f/ci.ts#L45-L70

On deno environment, module URL which starts with "./" should be resolved to the import map's URL.
https://deno.land/manual/linking_to_external_code/import_maps

This PR fixes this issue by resolving those relative paths into file URI schemes.