### PR TITLE
Fix: Assets cannot be rendered with chained extension

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -33,11 +33,13 @@ import type {
   default as ComponentLoader,
 } from "./core/component_loader.ts";
 import type {
+  Asset,
   Content,
   Data,
   Dest,
   Directory,
   Page,
+  Resource,
   Src,
 } from "./core/filesystem.ts";
 import type Source from "./core/source.ts";
@@ -64,6 +66,7 @@ type PluginSetup = ((options: unknown) => Plugin);
 type Plugin = (site: Site) => void;
 
 export type {
+  Asset,
   AssetLoader,
   Component,
   ComponentLoader,
@@ -98,6 +101,7 @@ export type {
   Reader,
   Renderer,
   RequestHandler,
+  Resource,
   ScopeFilter,
   Scopes,
   ScriptOptions,

--- a/core/asset_loader.ts
+++ b/core/asset_loader.ts
@@ -1,4 +1,4 @@
-import { Page } from "./filesystem.ts";
+import { Asset } from "./filesystem.ts";
 import Extensions from "./extensions.ts";
 import { join } from "../deps/path.ts";
 
@@ -28,8 +28,8 @@ export default class AssetLoader {
     extensions.forEach((extension) => this.loaders.set(extension, loader));
   }
 
-  /** Load an asset Page */
-  async load(path: string): Promise<Page | undefined> {
+  /** Load an Asset */
+  async load(path: string): Promise<Asset | undefined> {
     path = join("/", path);
 
     // Search for the loader
@@ -46,8 +46,8 @@ export default class AssetLoader {
       return;
     }
 
-    // Create the page
-    const page = new Page({
+    // Create the asset
+    const asset = new Asset({
       path: path.slice(0, -ext.length),
       lastModified: info?.mtime || undefined,
       created: info?.birthtime || undefined,
@@ -56,14 +56,14 @@ export default class AssetLoader {
 
     // Prepare the data
     const data = await this.reader.read(path, loader);
-    this.prepare(page, data);
-    page.data = data;
+    this.prepare(asset, data);
+    asset.data = data;
 
-    return page;
+    return asset;
   }
 
-  /** Prepare the data and the page */
-  prepare(_page: Page, data: Data): void {
+  /** Prepare the data and the asset */
+  prepare(_asset: Asset, data: Data): void {
     if (data.tags) {
       data.tags = Array.isArray(data.tags)
         ? data.tags.map((tag) => String(tag))

--- a/core/events.ts
+++ b/core/events.ts
@@ -1,4 +1,4 @@
-import type { Page } from "../core.ts";
+import type { Asset, Page } from "../core.ts";
 
 type Listener = [EventListener, EventOptions | undefined];
 
@@ -79,6 +79,12 @@ export interface Event {
    * contains the list of pages that have been saved
    */
   pages?: Page[];
+
+  /**
+   * Available only in "afterBuild" and "afterUpdate"
+   * contains the list of pages that have been saved
+   */
+  assets?: Asset[];
 }
 
 /** The available event types */

--- a/core/page_loader.ts
+++ b/core/page_loader.ts
@@ -10,6 +10,13 @@ import type { Data, Dest, Page, Src } from "../core.ts";
  * and ensure there's a `date` property in the data.
  */
 export default class PageLoader extends AssetLoader {
+  /** Load a Page */
+  load(path: string): Promise<Page | undefined> {
+    return AssetLoader.prototype.load.call(this, path) as Promise<
+      Page | undefined
+    >;
+  }
+
   /** Prepare the data and the page */
   prepare(page: Page, data: Data): void {
     super.prepare(page, data);

--- a/core/processors.ts
+++ b/core/processors.ts
@@ -1,7 +1,7 @@
 import { concurrent } from "./utils.ts";
 import { Exception } from "./errors.ts";
 
-import type { Page } from "../core.ts";
+import type { Resource } from "../core.ts";
 
 /**
  * Class to store and run the (pre)processors
@@ -27,10 +27,10 @@ export default class Processors {
   }
 
   /** Apply the processors to the provided pages */
-  async run(pages: Page[]): Promise<void> {
+  async run(resources: Resource[]): Promise<void> {
     for (const [process, exts] of this.processors) {
       await concurrent(
-        pages,
+        resources,
         async (page) => {
           try {
             if (
@@ -53,4 +53,4 @@ export default class Processors {
 }
 
 /** A (pre)processor */
-export type Processor = (page: Page) => void;
+export type Processor = (resource: Resource) => void;

--- a/core/scopes.ts
+++ b/core/scopes.ts
@@ -1,4 +1,4 @@
-import type { Page } from "../core.ts";
+import type { Resource } from "../core.ts";
 
 /**
  * Define independent updates scopes
@@ -7,9 +7,9 @@ import type { Page } from "../core.ts";
 export default class Scopes {
   scopes = new Set<ScopeFilter>();
 
-  /** Returns a function to filter the pages that must be rebuild */
-  getFilter(changedFiles: Iterable<string>): (page: Page) => boolean {
-    // There's no any scope, so rebuild all pages
+  /** Returns a function to filter the resources that must be rebuild */
+  getFilter(changedFiles: Iterable<string>): (resource: Resource) => boolean {
+    // There's no any scope, so rebuild all resources
     if (this.scopes.size === 0) {
       return () => true;
     }


### PR DESCRIPTION
## Describe the bug
You cannot get "hydration.client.tsx" rendered with a `_config.ts` below.
```ts
site.loadPages([".tsx"], moduleLoader, tsxEngine)
  .loadAssets([".client.tsx"], clientSideScriptLoader)
  .process([".client.tsx"], (page) => page.dest.ext = ".js")
```

## Background
The problem on code which directory causes the bug is that pages are always preferred over assets.
https://github.com/lumeland/lume/blob/f02e6832db31cc55f6da96fcab39213e50c17411/core/source.ts#L212-L213

1d67763c198972c202aed359f1f21e9f0f076aca fixes this, however, another problem occurrs.
In the current implementation, `Site.renderer.renderPages()` renders everything with `Site.renderer.engines.render()`. So when you have a matching extension in the engines, the file will be rendered by the corresponding engine even if the file is actually an asset, not a page.
https://github.com/lumeland/lume/blob/f02e6832db31cc55f6da96fcab39213e50c17411/core/renderer.ts#L88-L97 

To prevent this, we have to use `if` clause not to execute `engines.render()`for assets. However, we have no knowledge about the file in problem is an asset or a page on the context of `Site.renderer`.
So I implemented `Site.assets` array to store assets separately from `Site.pages`. To make it more natural, I also implemented a new class `Asset`, which is an analogue of `Page`.