### PR TITLE
Export hljs object

### DIFF
--- a/deps/highlight.ts
+++ b/deps/highlight.ts
@@ -1,4 +1,4 @@
-export { default } from "https://jspm.dev/highlight.js@11.2.0";
+export { default, type LanguageFn } from "https://jspm.dev/highlight.js@11.2.0";
 
 /** Options of the code highlighter */
 export interface HighlightOptions {

--- a/deps/highlight.ts
+++ b/deps/highlight.ts
@@ -1,4 +1,4 @@
-export { default, type LanguageFn } from "https://jspm.dev/highlight.js@11.2.0";
+export { default } from "https://jspm.dev/highlight.js@11.2.0";
 
 /** Options of the code highlighter */
 export interface HighlightOptions {
@@ -21,4 +21,300 @@ export interface HighlightOptions {
 
   /** An array of language names and aliases restricting auto detection to only these languages. */
   languages: unknown;
+}
+
+type MatchType = "begin" | "end" | "illegal";
+type EnhancedMatch = RegExpMatchArray & {
+  rule: CompiledMode;
+  type: MatchType;
+};
+type AnnotatedError = Error & {
+  mode?: Mode | Language;
+  languageName?: string;
+  badRule?: Mode;
+};
+
+type KeywordData = [string, number];
+type KeywordDict = Record<string, KeywordData>;
+
+export type HLJSApi = PublicApi & ModesAPI;
+
+export interface VuePlugin {
+  install: (vue: any) => void;
+}
+
+// perhaps make this an interface?
+type RegexEitherOptions = {
+  capture?: boolean;
+};
+
+interface PublicApi {
+  highlight: (
+    codeOrLanguageName: string,
+    optionsOrCode: string | HighlightOptions,
+    ignoreIllegals?: boolean
+  ) => HighlightResult;
+  highlightAuto: (
+    code: string,
+    languageSubset?: string[]
+  ) => AutoHighlightResult;
+  highlightBlock: (element: HTMLElement) => void;
+  highlightElement: (element: HTMLElement) => void;
+  configure: (options: Partial<HLJSOptions>) => void;
+  initHighlighting: () => void;
+  initHighlightingOnLoad: () => void;
+  highlightAll: () => void;
+  registerLanguage: (languageName: string, language: LanguageFn) => void;
+  unregisterLanguage: (languageName: string) => void;
+  listLanguages: () => string[];
+  registerAliases: (
+    aliasList: string | string[],
+    { languageName }: { languageName: string }
+  ) => void;
+  getLanguage: (languageName: string) => Language | undefined;
+  autoDetection: (languageName: string) => boolean;
+  inherit: <T>(original: T, ...args: Record<string, any>[]) => T;
+  addPlugin: (plugin: HLJSPlugin) => void;
+  debugMode: () => void;
+  safeMode: () => void;
+  versionString: string;
+  vuePlugin: () => VuePlugin;
+  regex: {
+    concat: (...args: (RegExp | string)[]) => string;
+    lookahead: (re: RegExp | string) => string;
+    either: (
+      ...args:
+        | (RegExp | string)[]
+        | [...(RegExp | string)[], RegexEitherOptions]
+    ) => string;
+    optional: (re: RegExp | string) => string;
+    anyNumberOfTimes: (re: RegExp | string) => string;
+  };
+}
+
+interface ModesAPI {
+  SHEBANG: (mode?: Partial<Mode> & { binary?: string | RegExp }) => Mode;
+  BACKSLASH_ESCAPE: Mode;
+  QUOTE_STRING_MODE: Mode;
+  APOS_STRING_MODE: Mode;
+  PHRASAL_WORDS_MODE: Mode;
+  COMMENT: (
+    begin: string | RegExp,
+    end: string | RegExp,
+    modeOpts?: Mode | {}
+  ) => Mode;
+  C_LINE_COMMENT_MODE: Mode;
+  C_BLOCK_COMMENT_MODE: Mode;
+  HASH_COMMENT_MODE: Mode;
+  NUMBER_MODE: Mode;
+  C_NUMBER_MODE: Mode;
+  BINARY_NUMBER_MODE: Mode;
+  REGEXP_MODE: Mode;
+  TITLE_MODE: Mode;
+  UNDERSCORE_TITLE_MODE: Mode;
+  METHOD_GUARD: Mode;
+  END_SAME_AS_BEGIN: (mode: Mode) => Mode;
+  // built in regex
+  IDENT_RE: string;
+  UNDERSCORE_IDENT_RE: string;
+  MATCH_NOTHING_RE: string;
+  NUMBER_RE: string;
+  C_NUMBER_RE: string;
+  BINARY_NUMBER_RE: string;
+  RE_STARTERS_RE: string;
+}
+
+export type LanguageFn = (hljs: HLJSApi) => Language;
+export type CompilerExt = (mode: Mode, parent: Mode | Language | null) => void;
+
+export interface HighlightResult {
+  code?: string;
+  relevance: number;
+  value: string;
+  language?: string;
+  illegal: boolean;
+  errorRaised?: Error;
+  // * for auto-highlight
+  secondBest?: Omit<HighlightResult, "second_best">;
+  // private
+  _illegalBy?: illegalData;
+  _emitter: Emitter;
+  _top?: Language | CompiledMode;
+}
+export interface AutoHighlightResult extends HighlightResult {}
+
+export interface illegalData {
+  message: string;
+  context: string;
+  index: number;
+  resultSoFar: string;
+  mode: CompiledMode;
+}
+
+export type BeforeHighlightContext = {
+  code: string;
+  language: string;
+  result?: HighlightResult;
+};
+export type PluginEvent = keyof HLJSPlugin;
+export type HLJSPlugin = {
+  "after:highlight"?: (result: HighlightResult) => void;
+  "before:highlight"?: (context: BeforeHighlightContext) => void;
+  "after:highlightElement"?: (data: {
+    el: Element;
+    result: HighlightResult;
+    text: string;
+  }) => void;
+  "before:highlightElement"?: (data: { el: Element; language: string }) => void;
+  // TODO: Old API, remove with v12
+  "after:highlightBlock"?: (data: {
+    block: Element;
+    result: HighlightResult;
+    text: string;
+  }) => void;
+  "before:highlightBlock"?: (data: {
+    block: Element;
+    language: string;
+  }) => void;
+};
+
+interface EmitterConstructor {
+  new (opts: any): Emitter;
+}
+
+export interface HighlightOptions {
+  language: string;
+  ignoreIllegals?: boolean;
+}
+
+export interface HLJSOptions {
+  noHighlightRe: RegExp;
+  languageDetectRe: RegExp;
+  classPrefix: string;
+  cssSelector: string;
+  languages?: string[];
+  __emitter: EmitterConstructor;
+  ignoreUnescapedHTML?: boolean;
+  throwUnescapedHTML?: boolean;
+}
+
+export interface CallbackResponse {
+  data: Record<string, any>;
+  ignoreMatch: () => void;
+  isMatchIgnored: boolean;
+}
+
+export type ModeCallback = (
+  match: RegExpMatchArray,
+  response: CallbackResponse
+) => void;
+export type Language = LanguageDetail & Partial<Mode>;
+export interface Mode extends ModeCallbacks, ModeDetails {}
+
+export interface LanguageDetail {
+  name?: string;
+  unicodeRegex?: boolean;
+  rawDefinition?: () => Language;
+  aliases?: string[];
+  disableAutodetect?: boolean;
+  contains: Mode[];
+  case_insensitive?: boolean;
+  keywords?: Record<string, any> | string;
+  isCompiled?: boolean;
+  exports?: any;
+  classNameAliases?: Record<string, string>;
+  compilerExtensions?: CompilerExt[];
+  supersetOf?: string;
+}
+
+// technically private, but exported for convenience as this has
+// been a pretty stable API and is quite useful
+export interface Emitter {
+  addKeyword(text: string, kind: string): void;
+  addText(text: string): void;
+  toHTML(): string;
+  finalize(): void;
+  closeAllNodes(): void;
+  openNode(kind: string): void;
+  closeNode(): void;
+  addSublanguage(emitter: Emitter, subLanguageName: string): void;
+}
+
+export type HighlightedHTMLElement = HTMLElement & {
+  result?: object;
+  secondBest?: object;
+  parentNode: HTMLElement;
+};
+
+/* modes */
+
+interface ModeCallbacks {
+  "on:end"?: Function;
+  "on:begin"?: ModeCallback;
+}
+
+export interface CompiledLanguage extends LanguageDetail, CompiledMode {
+  isCompiled: true;
+  contains: CompiledMode[];
+  keywords: Record<string, any>;
+}
+
+export type CompiledScope = Record<number, string> & {
+  _emit?: Record<number, boolean>;
+  _multi?: boolean;
+  _wrap?: string;
+};
+
+export type CompiledMode = Omit<Mode, "contains"> & {
+  begin?: RegExp | string;
+  end?: RegExp | string;
+  scope?: string;
+  contains: CompiledMode[];
+  keywords: KeywordDict;
+  data: Record<string, any>;
+  terminatorEnd: string;
+  keywordPatternRe: RegExp;
+  beginRe: RegExp;
+  endRe: RegExp;
+  illegalRe: RegExp;
+  matcher: any;
+  isCompiled: true;
+  starts?: CompiledMode;
+  parent?: CompiledMode;
+  beginScope?: CompiledScope;
+  endScope?: CompiledScope;
+};
+
+interface ModeDetails {
+  begin?: RegExp | string | (RegExp | string)[];
+  match?: RegExp | string | (RegExp | string)[];
+  end?: RegExp | string | (RegExp | string)[];
+  // deprecated in favor of `scope`
+  className?: string;
+  scope?: string | Record<number, string>;
+  beginScope?: string | Record<number, string>;
+  endScope?: string | Record<number, string>;
+  contains?: ("self" | Mode)[];
+  endsParent?: boolean;
+  endsWithParent?: boolean;
+  endSameAsBegin?: boolean;
+  skip?: boolean;
+  excludeBegin?: boolean;
+  excludeEnd?: boolean;
+  returnBegin?: boolean;
+  returnEnd?: boolean;
+  __beforeBegin?: Function;
+  parent?: Mode;
+  starts?: Mode;
+  lexemes?: string | RegExp;
+  keywords?: Record<string, any> | string;
+  beginKeywords?: string;
+  relevance?: number;
+  illegal?: string | RegExp | Array<string | RegExp>;
+  variants?: Mode[];
+  cachedVariants?: Mode[];
+  // parsed
+  subLanguage?: string | string[];
+  isCompiled?: boolean;
+  label?: string;
 }

--- a/plugins/code_highlight.ts
+++ b/plugins/code_highlight.ts
@@ -1,6 +1,8 @@
 import hljs, { HighlightOptions } from "../deps/highlight.ts";
 import { merge } from "../core/utils.ts";
 
+export { hljs };
+
 import type { Page, Site } from "../core.ts";
 
 export interface Options {

--- a/plugins/code_highlight.ts
+++ b/plugins/code_highlight.ts
@@ -1,13 +1,14 @@
-import hljs, { HighlightOptions } from "../deps/highlight.ts";
+import hljs, { HighlightOptions, LanguageFn } from "../deps/highlight.ts";
 import { merge } from "../core/utils.ts";
-
-export { hljs };
 
 import type { Page, Site } from "../core.ts";
 
 export interface Options {
   /** The list of extensions this plugin applies to */
   extensions: string[];
+
+  /** Register languages on the Highlight.js context. */
+  languages?: Record<string, LanguageFn>;
 
   /** Options passed to highlight.js */
   options: Partial<HighlightOptions>;
@@ -31,6 +32,12 @@ export default function (userOptions?: Partial<Options>) {
   const options = merge(defaults, userOptions);
   // @ts-ignore: Property 'configure' does not exist on type '{}'
   hljs.configure(options.options);
+
+  if (userOptions && userOptions.languages) {
+    for (const [name, fn] of Object.entries(userOptions.languages)) {
+      hljs.registerLangauge(name, fn);
+    }
+  }
 
   return (site: Site) => {
     site.process(options.extensions, codeHighlight);

--- a/plugins/code_highlight.ts
+++ b/plugins/code_highlight.ts
@@ -33,7 +33,7 @@ export default function (userOptions?: Partial<Options>) {
   // @ts-ignore: Property 'configure' does not exist on type '{}'
   hljs.configure(options.options);
 
-  if (userOptions && userOptions.languages) {
+  if (options.languages) {
     for (const [name, fn] of Object.entries(userOptions.languages)) {
       // @ts-ignore: Property 'registerLanguage' does not exist on type {}
       hljs.registerLangauge(name, fn);

--- a/plugins/code_highlight.ts
+++ b/plugins/code_highlight.ts
@@ -35,6 +35,7 @@ export default function (userOptions?: Partial<Options>) {
 
   if (userOptions && userOptions.languages) {
     for (const [name, fn] of Object.entries(userOptions.languages)) {
+      // @ts-ignore: Property 'registerLanguage' does not exist on type {}
       hljs.registerLangauge(name, fn);
     }
   }

--- a/plugins/code_highlight.ts
+++ b/plugins/code_highlight.ts
@@ -34,7 +34,7 @@ export default function (userOptions?: Partial<Options>) {
   hljs.configure(options.options);
 
   if (options.languages) {
-    for (const [name, fn] of Object.entries(userOptions.languages)) {
+    for (const [name, fn] of Object.entries(options.languages)) {
       // @ts-ignore: Property 'registerLanguage' does not exist on type {}
       hljs.registerLangauge(name, fn);
     }


### PR DESCRIPTION
Ability to register languages is missing without it. Workaround is to import the dependency manually, but urgh..