### PR TITLE
Prevent overwriting the output files

### DIFF
--- a/core/writer.ts
+++ b/core/writer.ts
@@ -77,14 +77,9 @@ export default class Writer {
     await ensureDir(dirname(filename));
 
     const file = await Deno.open(filename, { write: true, create: true });
-    await Deno.flock(file.rid);
     try {
-      // Prevent overwriting (often happens on case-insensitive file systems)
-      const stat = await file.stat();
-      if (stat.size !== 0) {
-        throw new Error(`File '${filename}' already exists.`);
-      }
-
+      await Deno.flock(file.rid);
+      await file.truncate();
       const contentStream = page.content instanceof Uint8Array
         ? page.content
         : new TextEncoder().encode(page.content);


### PR DESCRIPTION
Imagine you accidentally create two tags `blog` and `Blog`, and let Lume generate `_site/tags/blog/index.html` and `_site/tags/Blog/index.html` respectively (this is exactly what I did).
Case-insensitive filesystems regard those two files as the same, allowing Lume to overwrite one with the other.

This PR warns user that there already exist a generated file.