### PR TITLE
inline plugin generates invalid javascript

### DIFF
--- a/plugins/inline.ts
+++ b/plugins/inline.ts
@@ -122,7 +122,7 @@ export default function (userOptions?: Partial<Options>) {
       const path = posix.resolve(url, element.getAttribute("src")!);
 
       try {
-        element.innerHTML = await getContent(path);
+        element.textContent = await getContent(path);
         element.removeAttribute("src");
       } catch (cause) {
         site.logger.warn("Unable to inline the file", {


### PR DESCRIPTION
```javascript
element.innerHTML = await getContent(path);
```
This code causes unexpected html escaping like `>` => `&gt;`

I'm trying to write test.