### PR TITLE
fix: support relative path value in "lume" key in import map

### DIFF
--- a/core/utils.ts
+++ b/core/utils.ts
@@ -266,8 +266,7 @@ export async function getDenoConfig(): Promise<DenoConfig | undefined> {
   }
 }
 
-export async function loadImportMap(mapFile: string): Promise<ImportMap> {
-  const url = await toUrl(mapFile);
+export async function loadImportMap(url: URL): Promise<ImportMap> {
   return await (await fetch(url)).json() as ImportMap;
 }
 
@@ -283,7 +282,7 @@ export async function getImportMap(mapFile?: string): Promise<ImportMap> {
   };
 
   if (mapFile) {
-    const importMap = await loadImportMap(mapFile);
+    const importMap = await loadImportMap(await toUrl(mapFile));
 
     map.imports = { ...importMap.imports, ...map.imports };
     map.scopes = importMap.scopes;


### PR DESCRIPTION
I used `deno vendor vendor _config.ts serve.ts https://deno.land/x/lume@v1.7.4/cli.ts` on my project with lume which raised some issues in `deno vendor` related to the way jspm does things. I opened a couple PRs to fix this in Deno. After resolving these issues (which should be fixed in `1.21.2`), I found that lume was erroring when checking the version because I had modified the import map to point at my local vendored lume: `"lume/": "./deno.land/x/lume@v1.7.4/"` instead of the url.