### PR TITLE
Ignore `deno.jsonc`

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -55,6 +55,7 @@ export default function (
     .ignore("node_modules")
     .ignore("import_map.json")
     .ignore("deno.json")
+    .ignore("deno.jsonc")
     .ignore((path) => path.endsWith("/.DS_Store"))
     .use(url(pluginOptions.url))
     .use(json(pluginOptions.json))


### PR DESCRIPTION
Per https://deno.land/manual/getting_started/configuration_file, Deno config file can also use `deno.jsonc` as filename.