### PR TITLE
Warn user when empty files are skipped

### DIFF
--- a/core/site.ts
+++ b/core/site.ts
@@ -518,9 +518,19 @@ export default class Site {
     }
 
     // Remove empty pages and ondemand pages
-    this.pages = this.pages.filter((page) =>
-      !!page.content && !page.data.ondemand
-    );
+    this.pages = this.pages.filter((page) => {
+      const shouldSkip = !page.content || page.data.ondemand;
+      if (shouldSkip) {
+        this.logger.warn(
+          `Skipped page ${page.data.url} (${
+            page.data.ondemand
+              ? "page is build only on demand"
+              : "source file is empty"
+          })`,
+        );
+      }
+      return !shouldSkip;
+    });
 
     // Run the processors to the pages
     await this.processors.run(this.pages);

--- a/core/writer.ts
+++ b/core/writer.ts
@@ -56,6 +56,7 @@ export default class Writer {
   async savePage(page: Page): Promise<boolean> {
     // Ignore empty files or with url === false
     if (!page.content || page.data.url === false) {
+      this.logger.warn(`Skipped page ${page.data.url} (source file is empty)`);
       return false;
     }
 

--- a/core/writer.ts
+++ b/core/writer.ts
@@ -56,7 +56,13 @@ export default class Writer {
   async savePage(page: Page): Promise<boolean> {
     // Ignore empty files or with url === false
     if (!page.content || page.data.url === false) {
-      this.logger.warn(`Skipped page ${page.data.url} (source file is empty)`);
+      this.logger.warn(
+        `Skipped page ${page.data.url} (${
+          page.data.url === false
+            ? "page url is set to `false`"
+            : "source file is empty"
+        })`,
+      );
       return false;
     }
 


### PR DESCRIPTION
## What?

Logs a warning to tell the user when a file is being skipped from the build because it's empty.


## Why?

I was looking around the code for this bit of functionality and noticed that there was an open issue to add some logging. (Closes #180)

The issue was opened a while ago, so I don't know if it's still something you want to add. But because it was a small change I thought I might as well just submit a PR. Feel free to reject it if the issue isn't relevant anymore!


## Testing

This PR shouldn't affect functionality, and it doesn't seem like logging messages are something that should have unit tests attached to it. But if it's desirable to add a test here then I'm happy to do so.

On this topic, I was wondering if you have any tips on how to run a locally modified version of lume? I had a quick attempt but I was hitting some issues; I'm fairly new to Deno so I imagine that I'm missing something about how dependencies are resolved..