### PR TITLE
Fix: Update skip message text

### DIFF
--- a/core/site.ts
+++ b/core/site.ts
@@ -524,8 +524,8 @@ export default class Site {
         this.logger.warn(
           `Skipped page ${page.data.url} (${
             page.data.ondemand
-              ? "page is build only on demand"
-              : "source file is empty"
+              ? "page is built only on demand"
+              : "output content is empty"
           })`,
         );
       }

--- a/core/writer.ts
+++ b/core/writer.ts
@@ -60,7 +60,7 @@ export default class Writer {
         `Skipped page ${page.data.url} (${
           page.data.url === false
             ? "page url is set to `false`"
-            : "source file is empty"
+            : "output content is empty"
         })`,
       );
       return false;


### PR DESCRIPTION
Update the 'skipped page' message to reflect the fact that page content can be generated via functions, not only from static files.

(See [comment on previous PR](https://github.com/lumeland/lume/pull/221#issuecomment-1193386499).)

Also fixes a small typo (`build` -> `built`).