### PR TITLE
Reject invalid url slugs

### DIFF
--- a/core/renderer.ts
+++ b/core/renderer.ts
@@ -180,6 +180,14 @@ export default class Renderer {
       return;
     }
 
+    // Check that `url` is of a valid type
+    if (!["string", "function", "undefined"].includes(typeof url)) {
+      throw new Exception(
+        `The url variable must be either a string, function, or 'undefined'. The provided url is of type: ${typeof url}.`,
+        { page, url },
+      );
+    }
+
     if (typeof url === "function") {
       url = url(page);
     }

--- a/core/renderer.ts
+++ b/core/renderer.ts
@@ -180,14 +180,6 @@ export default class Renderer {
       return;
     }
 
-    // Check that `url` is of a valid type
-    if (!["string", "function", "undefined"].includes(typeof url)) {
-      throw new Exception(
-        `The url variable must be either a string, function, or 'undefined'. The provided url is of type: ${typeof url}.`,
-        { page, url },
-      );
-    }
-
     if (typeof url === "function") {
       url = url(page);
     }
@@ -210,6 +202,13 @@ export default class Renderer {
         dest.ext = posix.extname(url);
         dest.path = dest.ext ? url.slice(0, -dest.ext.length) : url;
       }
+    } else if (url !== undefined) {
+      // If the user has provided a value which hasn't yielded a string then it is an invalid url.
+      throw new Exception(
+        `If a url is specified, it should either be a string, or a function which returns a string. The provided url is of type: ${typeof url}.`,
+        { page, url },
+      );
+      // If the user hasn't provided a value, generate a url using Site settings.
     } else if (!this.formats.get(page.src.ext || "")?.asset) {
       // Handle subextensions, like styles.css.njk
       const subext = posix.extname(page.dest.path);

--- a/core/site.ts
+++ b/core/site.ts
@@ -524,8 +524,8 @@ export default class Site {
         this.logger.warn(
           `Skipped page ${page.data.url} (${
             page.data.ondemand
-              ? "page is build only on demand"
-              : "source file is empty"
+              ? "page is built only on demand"
+              : "output content is empty"
           })`,
         );
       }

--- a/core/writer.ts
+++ b/core/writer.ts
@@ -60,7 +60,7 @@ export default class Writer {
         `Skipped page ${page.data.url} (${
           page.data.url === false
             ? "page url is set to `false`"
-            : "source file is empty"
+            : "output content is empty"
         })`,
       );
       return false;


### PR DESCRIPTION
## What

Adds a check in `renderer` to make sure that the `url` provided is of a valid type. Throws an error if it is not.

## Why

Previously, the checks were structured so that if an invalid type was provided (e.g. a `number` or `array`) then the rendered would 'fail silently', falling back onto the default url scheme without warning the user. (Closes #222.)

## Testing

I've checked it locally against a few different values. Is this something you'd like unit tests for? I haven't written any here because I'm not familiar with the testing library etc., but I'm happy to spend some time trying to work it out if you'd like a test for it.