### PR TITLE
Add DOCTYPE to HTML document if missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - Numeric arguments passed to `search.pages()` are converted to numbers.
     For example `search.pages("foo=34")`, the `34` value is converted to number (previously it was a string, returning empty values)
   - Values with quotes are treated as strings. For example: `search.pages("foo='34'")`, the `34` value is a string.
+- If a HTML document is missing `<!DOCTYPE html>`, it's automatically added to the document with `documentToString` [#223].
 
 ## [1.10.1] - 2022-07-15
 ### Added

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -114,7 +114,7 @@ export function documentToString(document: HTMLDocument) {
   const { doctype, documentElement } = document;
 
   if (!doctype) {
-    return documentElement?.outerHTML || "";
+    return `<!DOCTYPE html>\n${documentElement?.outerHTML || ""}`;
   }
 
   return `<!DOCTYPE ${doctype.name}` +

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,12 @@
 import { assertEquals as equals } from "../deps/assert.ts";
-import { getImportMap, isPlainObject, merge, sha1 } from "../core/utils.ts";
+import {
+  documentToString,
+  getImportMap,
+  isPlainObject,
+  merge,
+  sha1,
+  stringToDocument,
+} from "../core/utils.ts";
 import { getPath } from "./utils.ts";
 import { React } from "../deps/react.ts";
 
@@ -109,4 +116,19 @@ Deno.test("merge import map", async () => {
       },
     },
   });
+});
+
+Deno.test("documentToString function should add doctype, if missing", () => {
+  const documentWithoutDoctype = stringToDocument(
+    `<html><head></head><body></body></html>`,
+  );
+  const documentWithDoctype = stringToDocument(
+    `<!DOCTYPE html><html><head></head><body></body></html>`,
+  );
+
+  const expected = `<!DOCTYPE html>
+<html><head></head><body></body></html>`;
+
+  equals(documentToString(documentWithoutDoctype), expected);
+  equals(documentToString(documentWithDoctype), expected);
 });


### PR DESCRIPTION
### Reference Issues/PRs

Closes #223

### What does this implement fix?

- If a HTML document is missing `<!DOCTYPE html>`, it's automatically added to the document with `documentToString` [#223].

### Testing

I added two tests for the `documentToString` function in `utils.test.ts`, to check if the function performs both conditions correctly, with `DOCTYPE` or without.