### PR TITLE
Add support for `deno.jsonc`

### DIFF
--- a/ci.ts
+++ b/ci.ts
@@ -10,6 +10,7 @@ import {
   mustNotifyUpgrade,
   toUrl,
 } from "./core/utils.ts";
+import { log } from "./cli/utils.ts";
 
 /**
  * This file works as a proxy to the actual Lume CLI to fix the following issues:
@@ -53,10 +54,6 @@ export async function getArgs(
 
   // Detect and use the deno.json file automatically
   const options = await getDenoConfig();
-
-  if (options) {
-    denoArgs.push(`--config=deno.json`);
-  }
 
   // Add the import-map option to Deno if it's missing
   const importMapArg = parsedArgs["import-map"] || options?.importMap;
@@ -172,15 +169,9 @@ function warn(...lines: (string | undefined)[]) {
   const syncWarn = args.includes("--serve") || args.includes("-s") ||
     args.includes("--watch") || args.includes("-w");
 
-  function log() {
-    console.log("----------------------------------------");
-    lines.forEach((line) => line && console.log(line));
-    console.log("----------------------------------------");
-  }
-
   if (syncWarn) {
-    log();
+    log(...lines);
   } else {
-    addEventListener("unload", log);
+    addEventListener("unload", () => log(...lines));
   }
 }

--- a/cli/import_map.ts
+++ b/cli/import_map.ts
@@ -1,5 +1,7 @@
-import { brightGreen } from "../deps/colors.ts";
+import { brightGreen, red } from "../deps/colors.ts";
+import { exists } from "../deps/fs.ts";
 import { baseUrl, getDenoConfig, getImportMap } from "../core/utils.ts";
+import { log } from "./utils.ts";
 
 /** Generate import_map.json and deno.json files */
 export default function () {
@@ -26,8 +28,17 @@ export async function importMap(url: URL) {
     config.importMap,
     JSON.stringify(importMap, null, 2) + "\n",
   );
-  await Deno.writeTextFile("deno.json", JSON.stringify(config, null, 2) + "\n");
 
-  console.log(brightGreen("Deno configuration file saved:"), "deno.json");
+  if (await exists("deno.jsonc")) {
+    log(
+      red("deno.jsonc needs to be manually updated:"),
+      JSON.stringify({ importMap: config.importMap, tasks: config.tasks }, null, 2),
+    );
+  } else {
+    await Deno.writeTextFile("deno.json", JSON.stringify(config, null, 2) + "\n");
+
+    console.log(brightGreen("Deno configuration file saved:"), "deno.json");
+  }
+
   console.log(brightGreen("Import map file saved:"), config.importMap);
 }

--- a/cli/import_map.ts
+++ b/cli/import_map.ts
@@ -1,7 +1,7 @@
-import { brightGreen, red } from "../deps/colors.ts";
+import { brightGreen } from "../deps/colors.ts";
 import { exists } from "../deps/fs.ts";
 import { baseUrl, getDenoConfig, getImportMap } from "../core/utils.ts";
-import { log } from "./utils.ts";
+import { promptConfigUpdate } from "./utils.ts";
 
 /** Generate import_map.json and deno.json files */
 export default function () {
@@ -30,14 +30,7 @@ export async function importMap(url: URL) {
   );
 
   if (await exists("deno.jsonc")) {
-    log(
-      red("deno.jsonc needs to be manually updated:"),
-      JSON.stringify(
-        { importMap: config.importMap, tasks: config.tasks },
-        null,
-        2,
-      ),
-    );
+    promptConfigUpdate({ importMap: config.importMap, tasks: config.tasks });
   } else {
     await Deno.writeTextFile(
       "deno.json",

--- a/cli/import_map.ts
+++ b/cli/import_map.ts
@@ -32,10 +32,17 @@ export async function importMap(url: URL) {
   if (await exists("deno.jsonc")) {
     log(
       red("deno.jsonc needs to be manually updated:"),
-      JSON.stringify({ importMap: config.importMap, tasks: config.tasks }, null, 2),
+      JSON.stringify(
+        { importMap: config.importMap, tasks: config.tasks },
+        null,
+        2,
+      ),
     );
   } else {
-    await Deno.writeTextFile("deno.json", JSON.stringify(config, null, 2) + "\n");
+    await Deno.writeTextFile(
+      "deno.json",
+      JSON.stringify(config, null, 2) + "\n",
+    );
 
     console.log(brightGreen("Deno configuration file saved:"), "deno.json");
   }

--- a/cli/upgrade.ts
+++ b/cli/upgrade.ts
@@ -65,8 +65,11 @@ export async function upgrade(dev = false, version?: string) {
 
 async function updateDenoConfig(url: URL) {
   try {
-    await Promise.all([
+    await Promise.any([
       Deno.stat("deno.json"),
+      Deno.stat("deno.jsonc"),
+    ])
+    await Promise.all([
       Deno.stat("import_map.json"),
     ]);
     await importMap(url);

--- a/cli/upgrade.ts
+++ b/cli/upgrade.ts
@@ -68,7 +68,7 @@ async function updateDenoConfig(url: URL) {
     await Promise.any([
       Deno.stat("deno.json"),
       Deno.stat("deno.jsonc"),
-    ])
+    ]);
     await Promise.all([
       Deno.stat("import_map.json"),
     ]);

--- a/cli/upgrade.ts
+++ b/cli/upgrade.ts
@@ -69,9 +69,7 @@ async function updateDenoConfig(url: URL) {
       Deno.stat("deno.json"),
       Deno.stat("deno.jsonc"),
     ]);
-    await Promise.all([
-      Deno.stat("import_map.json"),
-    ]);
+    await Deno.stat("import_map.json");
     await importMap(url);
   } catch {
     // Don't update import_map.json or deno.json

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -46,3 +46,9 @@ export const pluginNames = [
   "svgo",
   "terser",
 ];
+
+export function log(...lines: (string | undefined)[]) {
+  console.log("----------------------------------------");
+  lines.forEach((line) => line && console.log(line));
+  console.log("----------------------------------------");
+}

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -1,6 +1,6 @@
 import lume from "../mod.ts";
 import { toFileUrl } from "../deps/path.ts";
-import { dim } from "../deps/colors.ts";
+import { dim, red } from "../deps/colors.ts";
 import { getConfigFile } from "../core/utils.ts";
 
 import type { Site } from "../core.ts";
@@ -51,4 +51,11 @@ export function log(...lines: (string | undefined)[]) {
   console.log("----------------------------------------");
   lines.forEach((line) => line && console.log(line));
   console.log("----------------------------------------");
+}
+
+export function promptConfigUpdate(data: unknown) {
+  log(
+    red("deno.jsonc needs to be manually updated:"),
+    JSON.stringify(data, null, 2),
+  );
 }

--- a/cli/vendor.ts
+++ b/cli/vendor.ts
@@ -8,6 +8,8 @@ import {
   toUrl,
 } from "../core/utils.ts";
 import { join } from "../deps/path.ts";
+import { exists } from "../deps/fs.ts";
+import { promptConfigUpdate } from "./utils.ts";
 
 interface Options {
   output: string;
@@ -67,14 +69,18 @@ export async function vendor(
 
   // Update deno.json file
   denoConfig.importMap = importMapFile;
-  await Deno.writeTextFile(
-    join(root, "deno.json"),
-    JSON.stringify(denoConfig, null, 2) + "\n",
-  );
+  if (await exists("deno.jsonc")) {
+    promptConfigUpdate({ importMap: denoConfig.importMap });
+  } else {
+    await Deno.writeTextFile(
+      join(root, "deno.json"),
+      JSON.stringify(denoConfig, null, 2) + "\n",
+    );
 
-  console.log(brightGreen("Lume vendored to:"), output);
-  console.log(brightGreen("Deno configuration file saved:"), "deno.json");
-  console.log(brightGreen("Import map file saved:"), denoConfig.importMap);
+    console.log(brightGreen("Lume vendored to:"), output);
+    console.log(brightGreen("Deno configuration file saved:"), "deno.json");
+    console.log(brightGreen("Import map file saved:"), denoConfig.importMap);
+  }
 }
 
 async function run(output: string, urls: string[]) {

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -1,7 +1,7 @@
 import { DOMParser, HTMLDocument } from "../deps/dom.ts";
 import { join, posix, resolve, SEP, toFileUrl } from "../deps/path.ts";
 import { exists } from "../deps/fs.ts";
-import { stripJsonComments } from "../deps/strip-json-comments.ts";
+import { parse } from "../deps/jsonc.ts";
 import { Exception } from "./errors.ts";
 
 export const baseUrl = new URL("../", import.meta.url);
@@ -235,13 +235,8 @@ export interface DenoConfig {
 export async function getDenoConfig(): Promise<DenoConfig | undefined> {
   for (const configFile of ["deno.json", "deno.jsonc"]) {
     try {
-      let content = await Deno.readTextFile(configFile);
-
-      if (configFile.endsWith(".jsonc")) {
-        content = stripJsonComments(content);
-      }
-
-      return JSON.parse(content) as DenoConfig;
+      const content = await Deno.readTextFile(configFile);
+      return parse(content) as DenoConfig;
     } catch (err) {
       if (err instanceof Deno.errors.NotFound) {
         continue;

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -1,6 +1,7 @@
 import { DOMParser, HTMLDocument } from "../deps/dom.ts";
 import { join, posix, resolve, SEP, toFileUrl } from "../deps/path.ts";
 import { exists } from "../deps/fs.ts";
+import { stripJsonComments } from "../deps/strip-json-comments.ts";
 import { Exception } from "./errors.ts";
 
 export const baseUrl = new URL("../", import.meta.url);
@@ -232,15 +233,22 @@ export interface DenoConfig {
 }
 
 export async function getDenoConfig(): Promise<DenoConfig | undefined> {
-  try {
-    const content = await Deno.readTextFile("deno.json");
-    return JSON.parse(content) as DenoConfig;
-  } catch (err) {
-    if (err instanceof Deno.errors.NotFound) {
-      return;
-    }
+  for (const configFile of ["deno.json", "deno.jsonc"]) {
+    try {
+      let content = await Deno.readTextFile(configFile);
 
-    throw err;
+      if (configFile.endsWith(".jsonc")) {
+        content = stripJsonComments(content);
+      }
+
+      return JSON.parse(content) as DenoConfig;
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound) {
+        continue;
+      }
+
+      throw err;
+    }
   }
 }
 

--- a/deps/jsonc.ts
+++ b/deps/jsonc.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.150.0/encoding/jsonc.ts";

--- a/deps/strip-json-comments.ts
+++ b/deps/strip-json-comments.ts
@@ -1,1 +1,0 @@
-export { default as stripJsonComments } from "https://esm.sh/strip-json-comments@4.0.0";

--- a/deps/strip-json-comments.ts
+++ b/deps/strip-json-comments.ts
@@ -1,0 +1,1 @@
+export { default as stripJsonComments } from "https://esm.sh/strip-json-comments@4.0.0";

--- a/tests/assets/deno.jsonc
+++ b/tests/assets/deno.jsonc
@@ -1,6 +1,5 @@
 {
-  // A comment for spicing tests up
   "tasks": {
-    "foo": "echo bar"
+    "foo": "echo bar", // A trailing command and a comment for spicing tests up
   }
 }

--- a/tests/assets/deno.jsonc
+++ b/tests/assets/deno.jsonc
@@ -1,0 +1,6 @@
+{
+  // A comment for spicing tests up
+  "tasks": {
+    "foo": "echo bar"
+  }
+}

--- a/tests/assets/deno.jsonc
+++ b/tests/assets/deno.jsonc
@@ -1,5 +1,6 @@
 {
+  // deno-fmt-ignore
   "tasks": {
-    "foo": "echo bar", // A trailing command and a comment for spicing tests up
+    "foo": "echo bar", // A trailing comma and a comment for spicing tests up
   }
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -96,7 +96,7 @@ Deno.test("load deno.jsonc", async () => {
   const config = await getDenoConfig();
 
   equals(config?.tasks, { foo: "echo bar" });
-})
+});
 
 Deno.test("import map", async () => {
   const map = await getImportMap();

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals as equals } from "../deps/assert.ts";
 import {
   documentToString,
+  getDenoConfig,
   getImportMap,
   isPlainObject,
   merge,
@@ -89,6 +90,13 @@ Deno.test("sha1 function", async () => {
   equals(await sha1(data), expected);
   equals(await sha1(dataUint8), expected);
 });
+
+Deno.test("load deno.jsonc", async () => {
+  Deno.chdir(getPath("assets"));
+  const config = await getDenoConfig();
+
+  equals(config?.tasks, { foo: "echo bar" });
+})
 
 Deno.test("import map", async () => {
   const map = await getImportMap();


### PR DESCRIPTION
Resolve #211

See https://github.com/lumeland/lume/pull/209#issuecomment-1207332783

This is how it currently looks when calling `lume import-map` with `deno.jsonc`, not sure if this is the best approach:

<img width="610" alt="image" src="https://user-images.githubusercontent.com/44045911/183277238-c05ef06a-e1d6-4860-b99a-3d4184ee7230.png">
