### PR TITLE
Remove `--unstable` usage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      
+
       - name: Setup Deno environment
         uses: denoland/setup-deno@v1
         with:
@@ -34,6 +34,6 @@ jobs:
 
       - name: Run tests
         run: deno task test
-      
+
       - name: Test upgrade
-        run: deno run --unstable -A --no-check ci.ts upgrade
+        run: deno run -A --no-check ci.ts upgrade

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "deno.enable": true,
   "deno.lint": true,
-  "deno.unstable": true,
+  "deno.unstable": false,
   "deno.suggest.imports.hosts": {
     "https://deno.land": true,
     "https://esm.sh": false

--- a/ci.ts
+++ b/ci.ts
@@ -13,7 +13,7 @@ import {
 
 /**
  * This file works as a proxy to the actual Lume CLI to fix the following issues:
- * - Add defaults flags to Deno (--unstable, -A, --no-check)
+ * - Add defaults flags to Deno ( -A, --no-check)
  * - Adds user provided flags to Deno (for example --compact)
  * - Detect and set the lume --quiet flag in Deno.
  * - Detect and use the deno.json file automatically.
@@ -30,7 +30,6 @@ export async function getArgs(
   const sep = args.indexOf("--");
   const lumeArgs = sep === -1 ? args : args.slice(0, sep);
   const denoArgs = [
-    "--unstable",
     "-A",
     `--no-check`,
   ];

--- a/cli/upgrade.ts
+++ b/cli/upgrade.ts
@@ -93,7 +93,6 @@ async function install(url: string) {
     cmd: [
       Deno.execPath(),
       "run",
-      "--unstable",
       "-A",
       url + "install.ts",
       "--upgrade",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "test": "TZ=Z deno test --unstable -A --no-check=remote",
+    "test": "TZ=Z deno test -A --no-check=remote",
     "test:update": "deno task test -- --update",
     "install": "deno run -A install.ts",
     "changelog": "deno run --allow-read --allow-write https://deno.land/x/changelog@v2.1.0/bin.ts"

--- a/install.ts
+++ b/install.ts
@@ -17,7 +17,6 @@ const process = Deno.run({
   cmd: [
     Deno.execPath(),
     "install",
-    "--unstable",
     "-Af",
     `--no-check`,
     "--name=lume",


### PR DESCRIPTION
As of now Lume doesn't use any unstable feature (and probably won't in the future), so remove the option.