### PR TITLE
Added Index Signature to type PaginateResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.10.3] - Unreleased
+### Fixed
+- Improved `PaginateResult` type to support Index Signature `unknown`.
+
 ## [1.10.2] - 2022-08-11
 ### Added
 - New option `rules` to markdown plugin [#218].

--- a/plugins/paginate.ts
+++ b/plugins/paginate.ts
@@ -44,6 +44,8 @@ export interface PaginateResult<T> {
 
   /** The pagination info */
   pagination: PaginationInfo;
+
+  [key: string]: unknown;
 }
 
 export interface Options {


### PR DESCRIPTION
### Reference Issues/PRs

None

### What does this implement fix?

- Improved `PaginateResult` type to support Index Signature `unknown`.