### PR TITLE
Pass page in data for persistent plugin output

### DIFF
--- a/core/filesystem.ts
+++ b/core/filesystem.ts
@@ -438,6 +438,9 @@ export interface Data {
 
   /** The available components */
   comp?: ProxyComponents;
+  
+  /** The page object */
+  page?: Page;
 
   [index: string]: unknown;
 }

--- a/core/filesystem.ts
+++ b/core/filesystem.ts
@@ -438,7 +438,7 @@ export interface Data {
 
   /** The available components */
   comp?: ProxyComponents;
-  
+
   /** The page object */
   page?: Page;
 

--- a/core/renderer.ts
+++ b/core/renderer.ts
@@ -245,7 +245,7 @@ export default class Renderer {
 
   /** Render a page */
   async #renderPage(page: Page): Promise<Content> {
-    let data = { ...page.data };
+    let data = { ...page.data, page };
     let { content, layout } = data;
 
     // If the page is an asset, just return the content (don't render templates or layouts)


### PR DESCRIPTION
This provides an API surface for plugins to persist output generated on Remark's `vfile` or Markdown-it's `env`. This is also needed to fix #219 