### PR TITLE
Remove typo in jsx_preact plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Removed typo in `jsx_preact`, allowing `comp` function to execute properly.
+
 ## [1.12.1] - 2022-10-15
 ### Added
 - Show build duration and number of generated files [#283].

--- a/plugins/jsx_preact.ts
+++ b/plugins/jsx_preact.ts
@@ -69,7 +69,7 @@ export class PreactJsxEngine implements Engine {
       : content;
 
     if (element && typeof element === "object") {
-      element.toString = () => preact.renderToString(element);
+      element.toString = () => renderToString(element);
     }
 
     return element;

--- a/tests/__snapshots__/jsx_preact.test.ts.snap
+++ b/tests/__snapshots__/jsx_preact.test.ts.snap
@@ -1,6 +1,6 @@
 export const snapshot = {};
 
-snapshot[`build a site with jsx/tsx modules using Preact 1`] = `5`;
+snapshot[`build a site with jsx/tsx modules using Preact 1`] = `6`;
 
 snapshot[`build a site with jsx/tsx modules using Preact 2`] = `
 {
@@ -166,6 +166,34 @@ snapshot[`build a site with jsx/tsx modules using Preact 6`] = `
 
 snapshot[`build a site with jsx/tsx modules using Preact 7`] = `
 {
+  content: "<button>Hello</button>
+",
+  data: {
+    comp: {},
+    content: "{{ comp.button('primary') | safe }}
+",
+    date: 1970-01-01T00:00:00.000Z,
+    page: undefined,
+    paginate: [Function: paginate],
+    search: Search {},
+    tags: [
+    ],
+    url: "/with-comp/",
+  },
+  dest: {
+    ext: ".html",
+    path: "/with-comp/index",
+  },
+  src: {
+    ext: ".njk",
+    path: "/with-comp",
+    remote: undefined,
+  },
+}
+`;
+
+snapshot[`build a site with jsx/tsx modules using Preact 8`] = `
+{
   content: '<html><head><title>This is the title</title></head><body><main><h1>This is the title</h1><p>This is a JSX page <a href="/blog/">Go to home</a></p></main></body></html>',
   data: {
     comp: {},
@@ -192,7 +220,7 @@ snapshot[`build a site with jsx/tsx modules using Preact 7`] = `
 }
 `;
 
-snapshot[`build a site with jsx/tsx modules using Preact 8`] = `
+snapshot[`build a site with jsx/tsx modules using Preact 9`] = `
 {
   content: '<html><head><title>Markdown combined with JSX</title></head><body><main><div><h1 class="foo">Hello world</h1>
 <p>This is a <strong>markdown</strong> text. <a href="/">Go home</a></p>

--- a/tests/assets/jsx_preact/with-comp.njk
+++ b/tests/assets/jsx_preact/with-comp.njk
@@ -1,0 +1,1 @@
+{{ comp.button('primary') | safe }}


### PR DESCRIPTION
I removed a typo in `jsx_preact` plugin, so the `comp` function works properly. I also added tests for using `comp` with `jsx_preact`.