### PR TITLE
update jsx plugin setup to fix linting errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - For better compatibility, `postcss` and its plugins are loaded from `npm:` specifiers.
 - The `Page.dest` and `Page.updateDest` properties are deprecated.
   If you want to change the destination of a page, simply update the `Page.data.url` value.
+- JSX plugin now provides a jsx-runtime import to type `SX.IntrinsicElements`.
 
 ### Removed
 - `react_runtime` and `preact_runtime` dependencies.

--- a/plugins/jsx.ts
+++ b/plugins/jsx.ts
@@ -6,10 +6,12 @@ import type { Data, DenoConfigResult, Engine, Helper, Site } from "../core.ts";
 
 export interface Options {
   /** The list of extensions this plugin applies to */
-  extensions: string[] | {
-    pages: string[];
-    components: string[];
-  };
+  extensions:
+    | string[]
+    | {
+        pages: string[];
+        components: string[];
+      };
 }
 
 // Default options
@@ -53,11 +55,12 @@ export class JsxEngine implements Engine {
       });
     }
 
-    const element = typeof content === "object" && React.isValidElement(content)
-      ? content
-      : (typeof content === "function"
-        ? await content({ ...data, children }, this.helpers)
-        : content) as React.ReactElement;
+    const element =
+      typeof content === "object" && React.isValidElement(content)
+        ? content
+        : ((typeof content === "function"
+            ? await content({ ...data, children }, this.helpers)
+            : content) as React.ReactElement);
 
     if (React.isValidElement(element)) {
       return {
@@ -70,9 +73,8 @@ export class JsxEngine implements Engine {
   }
 
   renderSync(content: unknown, data: Data = {}): { toString(): string } {
-    const element = typeof content === "function"
-      ? content(data, this.helpers)
-      : content;
+    const element =
+      typeof content === "function" ? content(data, this.helpers) : content;
 
     if (React.isValidElement(element)) {
       return {
@@ -93,7 +95,12 @@ export class JsxEngine implements Engine {
 export function init(denoConfig: DenoConfigResult) {
   denoConfig.config.compilerOptions ||= {};
   denoConfig.config.compilerOptions.jsx = "react-jsx";
-  denoConfig.config.compilerOptions.jsxImportSource = "npm:react";
+  denoConfig.config.compilerOptions.jsxImportSource = "react";
+
+  // Add jsx-runtime import to import_map.
+  denoConfig.importMap ||= { imports: {} };
+  denoConfig.importMap.imports["react/jsx-runtime"] =
+    "https://esm.sh/react@18.2.0/jsx-runtime";
 }
 
 /** Register the plugin to support JSX and TSX files */

--- a/plugins/jsx.ts
+++ b/plugins/jsx.ts
@@ -9,9 +9,9 @@ export interface Options {
   extensions:
     | string[]
     | {
-        pages: string[];
-        components: string[];
-      };
+      pages: string[];
+      components: string[];
+    };
 }
 
 // Default options
@@ -55,12 +55,11 @@ export class JsxEngine implements Engine {
       });
     }
 
-    const element =
-      typeof content === "object" && React.isValidElement(content)
-        ? content
-        : ((typeof content === "function"
-            ? await content({ ...data, children }, this.helpers)
-            : content) as React.ReactElement);
+    const element = typeof content === "object" && React.isValidElement(content)
+      ? content
+      : ((typeof content === "function"
+        ? await content({ ...data, children }, this.helpers)
+        : content) as React.ReactElement);
 
     if (React.isValidElement(element)) {
       return {
@@ -73,8 +72,9 @@ export class JsxEngine implements Engine {
   }
 
   renderSync(content: unknown, data: Data = {}): { toString(): string } {
-    const element =
-      typeof content === "function" ? content(data, this.helpers) : content;
+    const element = typeof content === "function"
+      ? content(data, this.helpers)
+      : content;
 
     if (React.isValidElement(element)) {
       return {


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR updates the created `deno.json` and `import_map.json` files when using the JSX plugin to support TypeScript types for `SX.IntrinsicElements`.

## Related Issues

Before this any TSX template would throw this error:

```
JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
```

This update follows a discussion on Discord: https://discord.com/channels/794537085641818124/1040217450358255617 


### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
