### PR TITLE
Make filters available as a global variable in Pug

### DIFF
--- a/plugins/pug.ts
+++ b/plugins/pug.ts
@@ -40,6 +40,7 @@ type Compiler = typeof compile;
 export class PugEngine implements Engine {
   options: PugOptions;
   compiler: Compiler;
+  filters: Record<string, Helper> = {};
   cache = new Map<string, (data?: Data) => string>();
   basePath: string;
 
@@ -58,8 +59,15 @@ export class PugEngine implements Engine {
   }
 
   renderSync(content: string, data?: Data, filename?: string): string {
+    const dataWithFilters = { 
+      ...data,
+      filters: {
+        ...data?.filters, ...this.filters
+      }
+    };
+
     if (!filename) {
-      return this.compiler(content, this.options)(data);
+      return this.compiler(content, this.options)(dataWithFilters);
     }
     if (!this.cache.has(filename)) {
       this.cache.set(
@@ -71,7 +79,7 @@ export class PugEngine implements Engine {
       );
     }
 
-    return this.cache.get(filename)!(data);
+    return this.cache.get(filename)!(dataWithFilters);
   }
 
   addHelper(name: string, fn: Helper, options: HelperOptions) {
@@ -79,13 +87,14 @@ export class PugEngine implements Engine {
       case "filter": {
         this.options.filters ||= {};
 
-        const filter = (text: string, opt: Record<string, unknown>) => {
+        const filter: Helper = (text: string, opt: Record<string, unknown>) => {
           delete opt.filename;
           const args = Object.values(opt);
           return fn(text, ...args);
         };
 
-        this.options.filters[name] = filter as Helper;
+        this.filters[name] = fn;
+        this.options.filters[name] = filter;
         return;
       }
     }

--- a/plugins/pug.ts
+++ b/plugins/pug.ts
@@ -59,11 +59,12 @@ export class PugEngine implements Engine {
   }
 
   renderSync(content: string, data?: Data, filename?: string): string {
-    const dataWithFilters = { 
+    const dataWithFilters = {
       ...data,
       filters: {
-        ...data?.filters, ...this.filters
-      }
+        ...data?.filters,
+        ...this.filters,
+      },
     };
 
     if (!filename) {

--- a/tests/__snapshots__/pug.test.ts.snap
+++ b/tests/__snapshots__/pug.test.ts.snap
@@ -1,8 +1,8 @@
 export const snapshot = {};
 
-snapshot[`build a site with eta 1`] = `3`;
+snapshot[`build a site with pug 1`] = `3`;
 
-snapshot[`build a site with eta 2`] = `
+snapshot[`build a site with pug 2`] = `
 {
   formats: [
     {
@@ -72,12 +72,12 @@ snapshot[`build a site with eta 2`] = `
 }
 `;
 
-snapshot[`build a site with eta 3`] = `
+snapshot[`build a site with pug 3`] = `
 [
 ]
 `;
 
-snapshot[`build a site with eta 4`] = `
+snapshot[`build a site with pug 4`] = `
 {
   content: '<html class="no-js" lang="en"><head><meta charset="utf-8"/><title>Pug example</title></head><body><h1>Home</h1></body></html>',
   data: {
@@ -108,16 +108,16 @@ block content
 }
 `;
 
-snapshot[`build a site with eta 5`] = `
+snapshot[`build a site with pug 5`] = `
 {
   content: '<html class="no-js" lang="en"><head><meta charset="utf-8"/><title>Markdown content</title></head><body><h1>This is a title</h1>
 <p>This is a paragraph</p>
 <ul>
 <li>Option 1</li>
 <li>Option 2</li>
-</ul></body></html>',
+</ul><h1>Some dynamic content</h1></body></html>',
   data: {
-    content: "extends ./_includes/layout.pug
+    content: 'extends ./_includes/layout.pug
 block content
   :md
     # This is a title
@@ -126,7 +126,10 @@ block content
 
     - Option 1
     - Option 2
-",
+
+  - const dynamicMd = "# Some dynamic content";
+  != filters.md(dynamicMd)
+',
     date: 1970-01-01T00:00:00.000Z,
     page: undefined,
     paginate: [Function: paginate],
@@ -150,7 +153,7 @@ block content
 }
 `;
 
-snapshot[`build a site with eta 6`] = `
+snapshot[`build a site with pug 6`] = `
 {
   content: '<html class="no-js" lang="en"><head><meta charset="utf-8"/><title>Pug example</title></head><body><header><h1>Pug example</h1></header></body></html>',
   data: {

--- a/tests/assets/pug/filter.pug
+++ b/tests/assets/pug/filter.pug
@@ -11,3 +11,6 @@ block content
 
     - Option 1
     - Option 2
+
+  - const dynamicMd = "# Some dynamic content";
+  != filters.md(dynamicMd)

--- a/tests/pug.test.ts
+++ b/tests/pug.test.ts
@@ -1,7 +1,7 @@
 import { assertSiteSnapshot, build, getSite } from "./utils.ts";
 import pug from "../plugins/pug.ts";
 
-Deno.test("build a site with eta", async (t) => {
+Deno.test("build a site with pug", async (t) => {
   const site = getSite({
     src: "pug",
     location: new URL("https://example.com/blog"),


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

This PR makes filters registered by plugins and by the user available as a global variable in Pug templates.
Previously, filters are already exposed as Pug filters, which come with the unfortunate downside that all inputs must be in plain text and no dynamic inputs are allowed.
With this approach, dynamic variables can be used in filters like other template engines.

Example:
```pug
h1= filters.date(new Date(), "HUMAN_DATETIME")
```

Output:
```html
<h1>November 30th, 2022 at 9:57:16 AM GMT+8</h1>
````

## Related Issues

Fixes #320.

### Check List

- [X] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [X] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
