### PR TITLE
Resolve file URLs in source-map sources

### DIFF
--- a/plugins/source_maps.ts
+++ b/plugins/source_maps.ts
@@ -1,7 +1,7 @@
 import { isUrl, merge, normalizePath, read } from "../core/utils.ts";
 import { encode } from "../deps/base64.ts";
 import { Page } from "../core/filesystem.ts";
-import { basename, join, toFileUrl } from "../deps/path.ts";
+import { basename, fromFileUrl, join, toFileUrl } from "../deps/path.ts";
 
 import type { Site } from "../core.ts";
 
@@ -136,6 +136,11 @@ export function saveAsset(
     if (source.startsWith("deno:")) { // esbuild
       source = source.substring(5);
     }
+
+    if (source.startsWith("file:")) {
+      return fromFileUrl(source);
+    }
+
     if (isUrl(source)) {
       return source;
     }


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Sometimes, a source-map uses stringified file URLs in the "sources" field. Sass does this. On Linux, we get an error when we try to fetch the sources' contents, in order to write the actual source-map file. Somehow, the full posix path is appended to the root file URL. So I made sure we convert file URLs to paths.

For example, say we have a file "src/style.scss" in the working directory "/home/binyamin/project". The source is resolved to "**file:///home/binyamin/project**/home/binyamin/project/src/style.scss".

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
    send multiple pull request.
  - [ ] Write tests. (not applicable)
  - [x] Run deno `fmt` to fix
    the code format before commit.
  - [ ] Document any change in the
    `CHANGELOG.md`. (not applicable)
