### PR TITLE
Change og:title in lume metas plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Improved the `relations` plugin:
   - You can configure the key used to save the relations with `relationKey`.
   - You can configure the key used to save the multiple relations with `pluralRelationKey`.
+  - You can change the `type:og` in lume and default is website.
 
 ### Changed
 - `denosass` library has been replaced with [@lumeland/sass](https://www.npmjs.com/package/@lumeland/sass) NPM package

--- a/plugins/metas.ts
+++ b/plugins/metas.ts
@@ -20,6 +20,9 @@ export interface Options {
 }
 
 export interface MetaData {
+  /** The type of the site default is website */
+  type: string;
+
   /** The name of the site */
   site: string;
 
@@ -119,6 +122,7 @@ export default function (userOptions?: Partial<Options>) {
         ? new URL(site.url(metaImage), url).href
         : undefined;
 
+      const type = getMetaValue("type");
       const site_name = getMetaValue("site");
       const lang = getMetaValue("lang");
       const title = getMetaValue("title");
@@ -130,7 +134,7 @@ export default function (userOptions?: Partial<Options>) {
       const generator = getMetaValue("generator");
 
       // Open graph
-      addMeta(document, "property", "og:type", "website");
+      addMeta(document, "property", "og:type", type || "website");
       addMeta(document, "property", "og:site_name", site_name);
       addMeta(document, "property", "og:locale", lang);
       addMeta(document, "property", "og:title", title, 65);


### PR DESCRIPTION
`og:title` in the metas plugin fix and you can't change it according to your requirement. now you can change it and the default value is the `website`.

```yml
metas:
  type: blog
  site: Rajdeep Singh -- Learn computer science with an easy example. 
  twitter: "@Official_R_deep"
  icon: https://officialrajdeepsingh.dev/images/icon.png
  image: https://officialrajdeepsingh.dev/images/icon.png
  lang: en
  generator: true
```