### PR TITLE
remove extra console.log during init

### DIFF
--- a/core/utils.ts
+++ b/core/utils.ts
@@ -378,8 +378,6 @@ export async function writeDenoConfig(options: DenoConfigResult) {
 
   if (config.importMap) {
     const importMapFile = join(dirname(file), config.importMap);
-    console.log(importMapFile);
-
     await Deno.writeTextFile(
       importMapFile,
       JSON.stringify(importMap, null, 2) + "\n",


### PR DESCRIPTION
## Description

`import_map.json` was printed twice during `deno run -Ar https://deno.land/x/lume/init.ts`

```
Lume configuration file saved: _config.ts
import_map.json
Import map file saved: import_map.json
Deno configuration file saved: deno.json
Reloading Deno cache...
```