### PR TITLE
refactor: use outdented message on `install.ts`

### DIFF
--- a/deps/outdent.ts
+++ b/deps/outdent.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/x/outdent@v0.8.0/mod.ts";

--- a/install.ts
+++ b/install.ts
@@ -10,7 +10,7 @@ const process = Deno.run({
     "install",
     "--unstable",
     "-Af",
-    `--no-check`,
+    "--no-check",
     "--name=lume",
     import.meta.resolve("./ci.ts"),
   ],

--- a/install.ts
+++ b/install.ts
@@ -19,14 +19,22 @@ const process = Deno.run({
 const status = await process.status();
 process.close();
 
+const links = {
+  help: brightGreen("lume --help"),
+  issues: gray("https://github.com/lumeland/lume/issues/new"),
+  website: gray("https://lume.land"),
+  discord: gray("https://discord.gg/YbTmpACHWB"),
+  opencollective: gray("https://opencollective.com/lume"),
+} as const;
+
 if (!status.success) {
+  const { issues, discord } = links;
+
   const message = outdent`
 
     ${red("Error installing Lume")}
-    You can report an issue at ${
-    gray("https://github.com/lumeland/lume/issues/new")
-  }
-    Or get help at Discord: ${gray("https://discord.gg/YbTmpACHWB")}
+    You can report an issue at ${issues}
+    Or get help at Discord: ${discord}
 
   `;
 
@@ -35,6 +43,8 @@ if (!status.success) {
 }
 
 if (Deno.args[0] !== "--upgrade") {
+  const { help, website, discord, opencollective } = links;
+
   const message = outdent`
 
     🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
@@ -45,12 +55,10 @@ if (Deno.args[0] !== "--upgrade") {
 
     ${gray("-------------------------------")}
 
-    Run ${brightGreen("lume --help")} for usage information
-    See ${gray("https://lume.land")} for online documentation
-    See ${
-    gray("https://discord.gg/YbTmpACHWB")
-  } to propose new ideas and get help at Discord
-    See ${gray("https://opencollective.com/lume")} to provide some support
+    Run ${help} for usage information
+    See ${website} for online documentation
+    See ${discord} to propose new ideas and get help at Discord
+    See ${opencollective} to provide some support
 
   `;
 

--- a/install.ts
+++ b/install.ts
@@ -20,17 +20,17 @@ const status = await process.status();
 process.close();
 
 if (!status.success) {
-  console.log();
-  console.error(red("Error installing Lume"));
-  console.log(
-    `You can report an issue at ${
-      gray("https://github.com/lumeland/lume/issues/new")
-    }`,
-  );
-  console.log(
-    `Or get help at Discord: ${gray("https://discord.gg/YbTmpACHWB")}`,
-  );
-  console.log();
+  const message = outdent`
+
+    ${red("Error installing Lume")}
+    You can report an issue at ${
+    gray("https://github.com/lumeland/lume/issues/new")
+  }
+    Or get help at Discord: ${gray("https://discord.gg/YbTmpACHWB")}
+
+  `;
+
+  console.error(message);
   Deno.exit(1);
 }
 

--- a/install.ts
+++ b/install.ts
@@ -1,5 +1,6 @@
 import { brightGreen, gray, red } from "./deps/colors.ts";
 import { checkDenoVersion } from "./core/utils.ts";
+import { outdent } from "./deps/outdent.ts";
 
 checkDenoVersion();
 
@@ -34,26 +35,24 @@ if (!status.success) {
 }
 
 if (Deno.args[0] !== "--upgrade") {
-  console.log();
-  console.log("🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥");
-  console.log();
-  console.log(brightGreen(" Lume installed successfully!"));
-  console.log();
-  console.log("    BENVIDO - WELCOME! 🎉🎉");
-  console.log();
-  console.log(gray("-------------------------------"));
-  console.log();
-  console.log(`Run ${brightGreen("lume --help")} for usage information`);
-  console.log(
-    `See ${gray("https://lume.land")} for online documentation`,
-  );
-  console.log(
-    `See ${
-      gray("https://discord.gg/YbTmpACHWB")
-    } to propose new ideas and get help at Discord`,
-  );
-  console.log(
-    `See ${gray("https://opencollective.com/lume")} to provide some support`,
-  );
-  console.log();
+  const message = outdent`
+
+    🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
+
+    ${brightGreen(" Lume installed successfully!")}
+
+        BENVIDO - WELCOME! 🎉🎉
+
+    ${gray("-------------------------------")}
+
+    Run ${brightGreen("lume --help")} for usage information
+    See ${gray("https://lume.land")} for online documentation
+    See ${
+    gray("https://discord.gg/YbTmpACHWB")
+  } to propose new ideas and get help at Discord
+    See ${gray("https://opencollective.com/lume")} to provide some support
+
+  `;
+
+  console.log(message);
 }


### PR DESCRIPTION
## Description

- adds dependency [outdent](https://deno.land/x/outdent) which removes leading spaces in multi line template literal
- use outdented message on `install.ts`
- only print out to stderr when install fails

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)

      - [x] One pull request per feature. If you want to do more than one thing,
      send multiple pull request.
      - [x] Write tests. (message identical)
      - [x] Run deno `fmt` to fix
      the code format before commit.
      - [x] Document any change in the
      `CHANGELOG.md`. (no api changes)
