### PR TITLE
fix: specify `deno.config` path in `settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "editor.inlayHints.enabled": "off",
   "deno.enable": true,
   "deno.unstable": true,
+  "deno.config": "./deno.json",
   "deno.suggest.imports.hosts": {
     "https://deno.land": true
   }


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/54838975/218434555-5c5f8397-1bd1-4724-894c-89285f54bb54.png)

forces lume deno config to be used over global deno config.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)