### PR TITLE
refactor: type `reload_client.ts` (WIP)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,5 +5,8 @@
     "test:update": "deno task test -- --update",
     "install": "deno run -A install.ts",
     "changelog": "deno run --allow-read --allow-write https://deno.land/x/changelog@v2.1.0/bin.ts"
+  },
+  "compilerOptions": {
+    "lib": ["dom", "deno.ns"]
   }
 }

--- a/middlewares/reload_client.ts
+++ b/middlewares/reload_client.ts
@@ -1,5 +1,7 @@
+type Files = string[];
+
 export default function liveReload() {
-  let ws;
+  let ws: WebSocket | undefined;
   let wasClosed = false;
 
   function socket() {
@@ -50,7 +52,7 @@ export default function liveReload() {
 
   socket();
 
-  function refresh(files) {
+  function refresh(files: string[]) {
     let path = decodeURI(document.location.pathname);
 
     if (!path.endsWith(".html")) {
@@ -69,7 +71,7 @@ export default function liveReload() {
 
     for (const file of files) {
       const url = createUrl(file);
-      const format = url.pathname.split(".").pop().toLowerCase();
+      const format = url.pathname.split(".").pop()?.toLowerCase();
 
       switch (format) {
         case "css":
@@ -117,7 +119,7 @@ export default function liveReload() {
     }
   }
 
-  function styleIsImported(url, style) {
+  function styleIsImported(url: URL, style: CSSStyleSheet) {
     if (style.href === url.href) {
       return true;
     }
@@ -133,7 +135,7 @@ export default function liveReload() {
         continue;
       }
 
-      if (!rule.styleSheet.href.startsWith(url.origin)) {
+      if (!rule.styleSheet.href?.startsWith(url.origin)) {
         continue;
       }
 
@@ -145,16 +147,16 @@ export default function liveReload() {
     return false;
   }
 
-  function reloadSource(element) {
+  function reloadSource(element: HTMLImageElement) {
     const src = new URL(element.src);
-    src.searchParams.set("_cache", Date.now());
+    src.searchParams.set("_cache", Date.now().toString());
     element.src = src.href;
   }
 
-  function reloadStylesheet(element) {
+  function reloadStylesheet(element: Element | ProcessingInstruction) {
     const url = new URL(element.href);
 
-    url.searchParams.set("_cache", Date.now());
+    url.searchParams.set("_cache", Date.now().toString());
 
     const newElement = element.cloneNode();
     newElement.href = url.href;
@@ -162,11 +164,11 @@ export default function liveReload() {
     setTimeout(() => element.remove(), 500);
   }
 
-  function save(data) {
-    sessionStorage.setItem("lume-reload", JSON.stringify(data));
+  function save(files: Files) {
+    sessionStorage.setItem("lume-reload", JSON.stringify(files));
   }
 
-  function read() {
+  function read(): Files | undefined {
     const data = sessionStorage.getItem("lume-reload");
     sessionStorage.removeItem("lume-reload");
 
@@ -175,7 +177,7 @@ export default function liveReload() {
     }
   }
 
-  function createUrl(href) {
+  function createUrl(href: string) {
     // Remove search and hash
     const url = new URL(href, document.location.href);
     url.search = "";
@@ -184,7 +186,7 @@ export default function liveReload() {
     return url;
   }
 
-  function isSame(currentUrl, href) {
+  function isSame(currentUrl: URL, href: string) {
     const newUrl = createUrl(href);
 
     if (currentUrl.origin !== newUrl.origin) {


### PR DESCRIPTION
## Description

`reload_client.js` -> `reload_client.ts`

inferred function parameter with their input values, however these two functions may have incorrect (placeholder) types:
```ts
function styleIsImported(url: URL, style: CSSStyleSheet)
function reloadStylesheet(element: Element | ProcessingInstruction)
```

https://github.com/lumeland/lume/blob/73200d261f3bda81c04fb820d71e118aaca8060a/middlewares/reload_client.js#L125-L127
- [CSSStyleSheet](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet) [does not have origin attribute](https://github.com/microsoft/TypeScript/blob/098e18ebc1d31bb0523c735355e815817091116a/lib/lib.dom.d.ts#L3418-L3432)

https://github.com/lumeland/lume/blob/73200d261f3bda81c04fb820d71e118aaca8060a/middlewares/reload_client.js#L155-L160
- [Element](https://github.com/microsoft/TypeScript/blob/098e18ebc1d31bb0523c735355e815817091116a/lib/lib.dom.d.ts#L5010-L5119) | [ProcessingInstruction](https://github.com/microsoft/TypeScript/blob/098e18ebc1d31bb0523c735355e815817091116a/lib/lib.dom.d.ts#L11042-L11046) does not have `href` attribute

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)

      - [x] One pull request per feature. If you want to do more than one thing,
      send multiple pull request.
      - [ ] Write tests.
      - [x] Run deno `fmt` to fix
      the code format before commit.
      - [x] Document any change in the
      `CHANGELOG.md`.
