### PR TITLE
Support `.markdown` file extension for Markdown

### DIFF
--- a/plugins/markdown.ts
+++ b/plugins/markdown.ts
@@ -29,7 +29,7 @@ export interface Options {
 
 // Default options
 export const defaults: Options = {
-  extensions: [".md"],
+  extensions: [".md", ".markdown"],
   options: {
     html: true,
   },

--- a/tests/__snapshots__/base_path.test.ts.snap
+++ b/tests/__snapshots__/base_path.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`base_path plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/build.test.ts.snap
+++ b/tests/__snapshots__/build.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`build a simple site 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/code_highlight.test.ts.snap
+++ b/tests/__snapshots__/code_highlight.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`code_hightlight plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/esbuild.test.ts.snap
+++ b/tests/__snapshots__/esbuild.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`esbuild plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       asset: true,
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
@@ -176,6 +181,11 @@ snapshot[`esbuild plugin with splitting as true 2`] = `
     {
       engines: 1,
       ext: ".md",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
       pageLoader: [AsyncFunction: text],
     },
     {

--- a/tests/__snapshots__/eta.test.ts.snap
+++ b/tests/__snapshots__/eta.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`build a site with eta 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/filter_pages.test.ts.snap
+++ b/tests/__snapshots__/filter_pages.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Filter pages (allow all) 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,
@@ -373,6 +378,11 @@ snapshot[`Filter pages (allow only /multiple/*) 2`] = `
     {
       engines: 1,
       ext: ".md",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
       pageLoader: [AsyncFunction: text],
     },
     {

--- a/tests/__snapshots__/imagick.test.ts.snap
+++ b/tests/__snapshots__/imagick.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`imagick plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/inline.test.ts.snap
+++ b/tests/__snapshots__/inline.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`inline plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       asset: true,
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],

--- a/tests/__snapshots__/jsx.test.ts.snap
+++ b/tests/__snapshots__/jsx.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`build a site with jsx/tsx modules 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/jsx_preact.test.ts.snap
+++ b/tests/__snapshots__/jsx_preact.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`build a site with jsx/tsx modules using Preact 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/katex.test.ts.snap
+++ b/tests/__snapshots__/katex.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Katex plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/lightningcss.test.ts.snap
+++ b/tests/__snapshots__/lightningcss.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`lightningcss plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/liquid.test.ts.snap
+++ b/tests/__snapshots__/liquid.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`build a site with liquid 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/loaders.test.ts.snap
+++ b/tests/__snapshots__/loaders.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Load the pages of a site 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/markdown.test.ts.snap
+++ b/tests/__snapshots__/markdown.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Build a markdown site 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,
@@ -446,6 +451,11 @@ snapshot[`Build a markdown with hooks 2`] = `
     {
       engines: 1,
       ext: ".md",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
       pageLoader: [AsyncFunction: text],
     },
     {

--- a/tests/__snapshots__/mdx.test.ts.snap
+++ b/tests/__snapshots__/mdx.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Build a mdx site 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/metas.test.ts.snap
+++ b/tests/__snapshots__/metas.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`metas plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/minify_html.test.ts.snap
+++ b/tests/__snapshots__/minify_html.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`minify_html plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/module.test.ts.snap
+++ b/tests/__snapshots__/module.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Build a site with js/ts modules 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/multilanguage.test.ts.snap
+++ b/tests/__snapshots__/multilanguage.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`multilanguage plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/netlify_cms.test.ts.snap
+++ b/tests/__snapshots__/netlify_cms.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`code_hightlight plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/nunjucks.test.ts.snap
+++ b/tests/__snapshots__/nunjucks.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`build a site with nunjucks 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/pagefind.test.ts.snap
+++ b/tests/__snapshots__/pagefind.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Pagefind plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/postcss.test.ts.snap
+++ b/tests/__snapshots__/postcss.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`postcss plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,
@@ -208,6 +213,11 @@ snapshot[`postcss plugin without includes 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,
@@ -363,6 +373,11 @@ snapshot[`postcss plugin with hooks 2`] = `
     {
       engines: 1,
       ext: ".md",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
       pageLoader: [AsyncFunction: text],
     },
     {

--- a/tests/__snapshots__/pretty_urls.test.ts.snap
+++ b/tests/__snapshots__/pretty_urls.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Disabled pretty URLs 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/prism.test.ts.snap
+++ b/tests/__snapshots__/prism.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Prism plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/pug.test.ts.snap
+++ b/tests/__snapshots__/pug.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`build a site with pug 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/relations.test.ts.snap
+++ b/tests/__snapshots__/relations.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`relations plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/relative_urls.test.ts.snap
+++ b/tests/__snapshots__/relative_urls.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`relative_url plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/remark.test.ts.snap
+++ b/tests/__snapshots__/remark.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Build a markdown site 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/remote_files.test.ts.snap
+++ b/tests/__snapshots__/remote_files.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`render remote files 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       asset: true,
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],

--- a/tests/__snapshots__/render_order.test.ts.snap
+++ b/tests/__snapshots__/render_order.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`render order property 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/resolve_urls.test.ts.snap
+++ b/tests/__snapshots__/resolve_urls.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`relative_url plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/sass.test.ts.snap
+++ b/tests/__snapshots__/sass.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`sass plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/sheets.test.ts.snap
+++ b/tests/__snapshots__/sheets.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Sheets plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/sitemap.test.ts.snap
+++ b/tests/__snapshots__/sitemap.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Sitemap plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/slugify_urls.test.ts.snap
+++ b/tests/__snapshots__/slugify_urls.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`slugify_urls plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/source_maps.test.ts.snap
+++ b/tests/__snapshots__/source_maps.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Source maps from CSS files 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,
@@ -231,6 +236,11 @@ snapshot[`Source maps from Js files 2`] = `
     {
       engines: 1,
       ext: ".md",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
       pageLoader: [AsyncFunction: text],
     },
     {

--- a/tests/__snapshots__/static_files.test.ts.snap
+++ b/tests/__snapshots__/static_files.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`Copy static files 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       copy: true,
       dataLoader: [AsyncFunction: module],

--- a/tests/__snapshots__/svgo.test.ts.snap
+++ b/tests/__snapshots__/svgo.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`terser plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/__snapshots__/tailwindcss.test.ts.snap
+++ b/tests/__snapshots__/tailwindcss.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`postcss plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       asset: true,
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],

--- a/tests/__snapshots__/terser.test.ts.snap
+++ b/tests/__snapshots__/terser.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`terser plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       asset: true,
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],

--- a/tests/__snapshots__/url.test.ts.snap
+++ b/tests/__snapshots__/url.test.ts.snap
@@ -31,6 +31,11 @@ snapshot[`url and htmlUrl update href 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,
@@ -185,6 +190,11 @@ snapshot[`configure url and htmlUrl names 2`] = `
     {
       engines: 1,
       ext: ".md",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
       pageLoader: [AsyncFunction: text],
     },
     {

--- a/tests/__snapshots__/windi_css.test.ts.snap
+++ b/tests/__snapshots__/windi_css.test.ts.snap
@@ -37,6 +37,11 @@ snapshot[`Windi CSS plugin 2`] = `
       pageLoader: [AsyncFunction: text],
     },
     {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
       componentLoader: [AsyncFunction: module],
       dataLoader: [AsyncFunction: module],
       engines: 1,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -116,7 +116,7 @@ Deno.test("data configuration", () => {
   const site = lume();
   const { formats } = site;
 
-  equals(formats.size, 10);
+  equals(formats.size, 11);
   equals(formats.has(".json"), true);
   assert(formats.get(".json")?.dataLoader);
   equals(formats.has(".js"), true);
@@ -131,7 +131,7 @@ Deno.test("data configuration", () => {
   const loader = () => Promise.resolve({});
   site.loadData([".ext1", ".ext2"], loader);
 
-  equals(formats.size, 12);
+  equals(formats.size, 13);
   equals(formats.get(".ext1")?.dataLoader, loader);
   equals(formats.get(".ext2")?.dataLoader, loader);
 });
@@ -140,7 +140,7 @@ Deno.test("pages configuration", () => {
   const site = lume();
   const { formats } = site;
 
-  equals(formats.size, 10);
+  equals(formats.size, 11);
 
   const extensions = [
     ".tmpl.json",
@@ -174,7 +174,7 @@ Deno.test("pages configuration", () => {
 
   site.loadPages(newExts, loader, engine);
 
-  equals(formats.size, 12);
+  equals(formats.size, 13);
 
   for (const ext of newExts) {
     equals(formats.has(ext), true);
@@ -187,7 +187,7 @@ Deno.test("assets configuration", () => {
   const site = lume();
   const { formats } = site;
 
-  equals(formats.size, 10);
+  equals(formats.size, 11);
 
   const loader = () => Promise.resolve({});
 
@@ -198,7 +198,7 @@ Deno.test("assets configuration", () => {
 
   site.loadAssets(extensions, loader);
 
-  equals(formats.size, 11);
+  equals(formats.size, 12);
   for (const ext of extensions) {
     equals(formats.has(ext), true);
     assert(formats.get(ext)?.pageLoader);


### PR DESCRIPTION
## Description

The Markdown plugin should support files that use either `.md` or `.markdown` extensions as both are valid.[^1][^2]

[^1]: https://daringfireball.net/linked/2014/01/08/markdown-extension
[^2]: https://datatracker.ietf.org/doc/html/rfc7763

## Related Issues

Fixes #386

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)

      - [x] One pull request per feature. If you want to do more than one thing,
      send multiple pull request.
      - [ ] Write tests.
      - [x] Run deno `fmt` to fix
      the code format before commit.
      - [ ] Document any change in the
      `CHANGELOG.md`.
