### PR TITLE
Support downloading Pagefind prerelease versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project try to adheres to [Semantic Versioning](https://semver.org/),
 but not always is possible (due the use of unstable features from Deno).
 Any BREAKING CHANGE between minor versions will be documented here in upper case.
 
+## [1.15.4] - Unreleased
+### Added
+- Added support for using prerelease versions of Pagefind [#388].
+
 ## [1.15.3] - 2023-02-20
 ### Added
 - New hook `markdownIt` to modify the `MarkdownIt` instance directly.
@@ -2094,7 +2098,9 @@ The first version.
 [#364]: https://github.com/lumeland/lume/issues/364
 [#369]: https://github.com/lumeland/lume/issues/369
 [#374]: https://github.com/lumeland/lume/issues/374
+[#388]: https://github.com/lumeland/lume/issues/388
 
+[1.15.4]: https://github.com/lumeland/lume/compare/v1.15.3...HEAD
 [1.15.3]: https://github.com/lumeland/lume/compare/v1.15.2...v1.15.3
 [1.15.2]: https://github.com/lumeland/lume/compare/v1.15.1...v1.15.2
 [1.15.1]: https://github.com/lumeland/lume/compare/v1.15.0...v1.15.1

--- a/deps/pagefind.ts
+++ b/deps/pagefind.ts
@@ -16,10 +16,12 @@ export default async function downloadBinary(
 ): Promise<string> {
   const { path, extended, version } = options;
   const prefix = extended ? "_extended" : "";
+  const isPrerelease = /v\d+\.\d+\.\d+-.+$/.test(version);
+  const repository = isPrerelease ? "pagefind-beta" : "pagefind";
 
   return await dbin({
     pattern:
-      `https://github.com/CloudCannon/pagefind/releases/download/{version}/pagefind${prefix}-{version}-{target}.tar.gz`,
+      `https://github.com/CloudCannon/${repository}/releases/download/{version}/pagefind${prefix}-{version}-{target}.tar.gz`,
     version,
     targets: [
       { name: "x86_64-unknown-linux-musl", os: "linux", arch: "x86_64" },


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Pagefind has started publishing prerelease binaries via a second repository, [CloudCannon/pagefind-beta](https://github.com/CloudCannon/pagefind-beta/releases). This PR checks the version string and uses the beta repository as needed. The condition here matches the condition in Pagefind's [npx wrapper package](https://github.com/CloudCannon/pagefind/blob/9bfd85649da4c3ac5e359589c8f229eb0006e0eb/wrappers/node/lib/download.js#L153).

## Related Issues

N/A

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)

      - [x] One pull request per feature. If you want to do more than one thing,
      send multiple pull request.
      - [ ] Write tests.
      - [x] Run deno `fmt` to fix
      the code format before commit.
      - [x] Document any change in the
      `CHANGELOG.md`.