### PR TITLE
refactor: export PluginOptions

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -13,7 +13,7 @@ import { merge } from "./core/utils.ts";
 import type { DeepPartial } from "./core/utils.ts";
 import type { SiteOptions } from "./core/site.ts";
 
-interface PluginOptions {
+export interface PluginOptions {
   url?: Partial<UrlOptions>;
   json?: Partial<JsonOptions>;
   markdown?: Partial<MarkdownOptions>;
@@ -57,12 +57,7 @@ export default function lume(
 
 function getOptionsFromCli(): DeepPartial<SiteOptions> {
   const options = parse(Deno.args, {
-    string: [
-      "src",
-      "dest",
-      "location",
-      "port",
-    ],
+    string: ["src", "dest", "location", "port"],
     boolean: ["quiet", "dev", "serve", "open"],
     alias: { dev: "d", serve: "s", port: "p", open: "o" },
     ["--"]: true,


### PR DESCRIPTION
## Description

```ts
type PluginOptions = NonNullable<Parameters<typeof lume>[1]>['markdown'] // before
import {type PluginOptions} from "lume/mod.ts" // after

const markdown = {
  plugins: [anchor],
  keepDefaultPlugins: true,
} satisfies PluginOptions
```
it could be useful to pass pass type safe plugin configuration object into lume. exported `PluginOptions` to enable typing plugin objects.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
      - [x] One pull request per feature. If you want to do more than one thing,
      send multiple pull request.
      - [ ] Write tests.
      - [x] Run deno `fmt` to fix
      the code format before commit.
      - [ ] Document any change in the
      `CHANGELOG.md`.
