### PR TITLE
fix: Site.copy doing nothing for trailing slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project try to adheres to [Semantic Versioning](https://semver.org/),
 but not always is possible (due the use of unstable features from Deno).
 Any BREAKING CHANGE between minor versions will be documented here in upper case.
 
+## [Unreleased]
+
+### Fixed
+
+- `Site.copy` now works as expected when given a path with a trailing slash. [#426]
+
 ## [1.17.4] - 2023-05-25
 ### Added
 - The env variable `LUME_ENV=development` is created when `deno task lume --dev`.
@@ -2254,6 +2260,7 @@ The first version.
 [#417]: https://github.com/lumeland/lume/issues/417
 [#418]: https://github.com/lumeland/lume/issues/418
 [#419]: https://github.com/lumeland/lume/issues/419
+[#426]: https://github.com/lumeland/lume/pull/426
 
 [1.17.4]: https://github.com/lumeland/lume/compare/v1.17.3...v1.17.4
 [1.17.3]: https://github.com/lumeland/lume/compare/v1.17.2...v1.17.3

--- a/tests/__snapshots__/static_files.test.ts.snap
+++ b/tests/__snapshots__/static_files.test.ts.snap
@@ -102,6 +102,16 @@ snapshot[`Copy static files 2`] = `
     outputPath: "/other/two",
   },
   {
+    entry: "/other2/one",
+    flags: [],
+    outputPath: "/other2/one",
+  },
+  {
+    entry: "/other2/two",
+    flags: [],
+    outputPath: "/other2/two",
+  },
+  {
     entry: "/posts/2022-01-01_first-post/assets/inner/inner2/styles.scss",
     flags: [],
     outputPath: "/posts/first-post/assets/inner/inner2/styles.css",

--- a/tests/assets/static_files/other2/one
+++ b/tests/assets/static_files/other2/one
@@ -1,0 +1,1 @@
+content

--- a/tests/assets/static_files/other2/two
+++ b/tests/assets/static_files/other2/two
@@ -1,0 +1,1 @@
+content

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -25,18 +25,18 @@ Deno.test("static files configuration", () => {
   site.copy("img");
   equals(staticPaths.size, 1);
   equals(staticPaths.has("/img"), true);
-  equals(staticPaths.get("/img"), undefined);
+  equals(staticPaths.get("/img")!.dest, undefined);
 
   site.copy("statics/favicon.ico", "favicon.ico");
   equals(staticPaths.size, 2);
   equals(
-    staticPaths.get("/statics/favicon.ico"),
+    staticPaths.get("/statics/favicon.ico")!.dest,
     "/favicon.ico",
   );
 
   site.copy("css", ".");
   equals(staticPaths.size, 3);
-  equals(staticPaths.get("/css"), "/");
+  equals(staticPaths.get("/css")!.dest, "/");
 });
 
 Deno.test("ignored files configuration", () => {

--- a/tests/static_files.test.ts
+++ b/tests/static_files.test.ts
@@ -21,6 +21,12 @@ Deno.test("Copy static files", async (t) => {
     (file) => "/subdir" + file.replace(/\.copy2/, ".copy3"),
   );
 
+  // copied with the trailing slash
+  site.copy("other2/");
+
+  // not copied because of the trailing slash
+  site.copy("three.no/");
+
   await build(site);
   await assertSiteSnapshot(t, site);
 });


### PR DESCRIPTION
Previously

    site.copy("static/");

had no effect whatsoever because of the trailing slash.

This commit fixes this bug to recognize the trailing slash and remove it. The trailing slash is still significant since:

    site.copy("foo/");

will now only copy a directory "foo" but not a file named "foo" (as you would expect).

Fixes #425.