### PR TITLE
fix: error on comment-only YAML front matter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Any BREAKING CHANGE between minor versions will be documented here in upper case
 ### Fixed
 
 - `Site.copy` now works as expected when given a path with a trailing slash. [#426]
+- YAML front matters containing only a comment no longer result in an error.
 
 ## [1.17.4] - 2023-05-25
 ### Added

--- a/core/loaders/text.ts
+++ b/core/loaders/text.ts
@@ -8,7 +8,8 @@ export default async function text(path: string): Promise<Data> {
   const content = await read(path, false);
 
   if (test(content)) {
-    const { attrs = {}, body } = extract<Data>(content);
+    let { attrs, body } = extract<Data>(content);
+    attrs ??= {};
     attrs.content = body;
 
     return attrs;

--- a/tests/assets/frontmatter-only-comment.md
+++ b/tests/assets/frontmatter-only-comment.md
@@ -1,0 +1,3 @@
+---
+# Nothing here.
+---

--- a/tests/loaders.test.ts
+++ b/tests/loaders.test.ts
@@ -1,5 +1,6 @@
-import { assert, assertStrictEquals as equals } from "../deps/assert.ts";
+import { assert, assertEquals, assertStrictEquals } from "../deps/assert.ts";
 import binaryLoader from "../core/loaders/binary.ts";
+import textLoader from "../core/loaders/text.ts";
 import { assertSiteSnapshot, build, getPage, getSite } from "./utils.ts";
 
 Deno.test("Load the pages of a site", async (t) => {
@@ -38,5 +39,14 @@ Deno.test("ignored draft pages on dev=false", async () => {
 
   await build(site);
 
-  equals(site.pages.length, 6);
+  assertStrictEquals(site.pages.length, 6);
+});
+
+Deno.test("textLoader with frontmatter containing just a comment", async () => {
+  assertEquals(
+    await textLoader(
+      import.meta.resolve("./assets/frontmatter-only-comment.md"),
+    ),
+    { content: "" },
+  );
 });


### PR DESCRIPTION
YAML front matters such as the following:

    ---
    # Nothing here.
    ---

previously resulted in:

    error: TypeError: Cannot set properties of null (setting 'content')

which as it turns out was caused by this Deno standard library peculiarity:

    > import {parse} from "https://deno.land/std@0.189.0/yaml/parse.ts";
    > parse('')
    undefined
    > parse('# test')
    null