### PR TITLE
Add JSONC support for JSON Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Any BREAKING CHANGE between minor versions will be documented here in upper case
 ### Added
 - TOML Plugin [#432]
 
+### Changed
+- JSON Plugin supports `.jsonc` files [#433]
+
 ## [1.17.5] - 2023-06-08
 ### Fixed
 - `Site.copy` now works as expected when given a path with a trailing slash. [#426]
@@ -2269,6 +2272,7 @@ The first version.
 [#426]: https://github.com/lumeland/lume/issues/426
 [#431]: https://github.com/lumeland/lume/issues/431
 [#432]: https://github.com/lumeland/lume/issues/432
+[#433]: https://github.com/lumeland/lume/issues/433
 
 [1.18.0]: https://github.com/lumeland/lume/compare/v1.17.5...HEAD
 [1.17.5]: https://github.com/lumeland/lume/compare/v1.17.4...v1.17.5

--- a/core/loaders/json.ts
+++ b/core/loaders/json.ts
@@ -1,11 +1,12 @@
+import { parse } from "../../deps/jsonc.ts";
 import { isPlainObject, read } from "../utils.ts";
 
 import type { Data } from "../../core.ts";
 
-/** Load and parse a JSON file */
+/** Load and parse a JSON / JSONC file */
 export default async function json(path: string): Promise<Data> {
   const text = await read(path, false);
-  const content = JSON.parse(text);
+  const content = parse(text);
 
   if (!content) {
     return {};

--- a/core/loaders/json.ts
+++ b/core/loaders/json.ts
@@ -6,7 +6,7 @@ import type { Data } from "../../core.ts";
 /** Load and parse a JSON / JSONC file */
 export default async function json(path: string): Promise<Data> {
   const text = await read(path, false);
-  const content = parse(text);
+  const content = path.endsWith(".jsonc") ? parse(text) : JSON.parse(text);
 
   if (!content) {
     return {};

--- a/plugins/json.ts
+++ b/plugins/json.ts
@@ -14,8 +14,8 @@ export interface Options {
 // Default options
 export const defaults: Options = {
   extensions: {
-    data: [".json"],
-    pages: [".tmpl.json"],
+    data: [".json", ".jsonc"],
+    pages: [".tmpl.json", ".tmpl.jsonc"],
   },
 };
 

--- a/tests/__snapshots__/base_path.test.ts.snap
+++ b/tests/__snapshots__/base_path.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`base_path plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`base_path plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/build.test.ts.snap
+++ b/tests/__snapshots__/build.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`build a simple site 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`build a simple site 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/code_highlight.test.ts.snap
+++ b/tests/__snapshots__/code_highlight.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`code_hightlight plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`code_hightlight plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/esbuild.test.ts.snap
+++ b/tests/__snapshots__/esbuild.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`esbuild plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`esbuild plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,
@@ -168,6 +178,11 @@ snapshot[`esbuild plugin with splitting as true 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -175,6 +190,11 @@ snapshot[`esbuild plugin with splitting as true 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/eta.test.ts.snap
+++ b/tests/__snapshots__/eta.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`build a site with eta 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`build a site with eta 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/feed.test.ts.snap
+++ b/tests/__snapshots__/feed.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`RSS plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`RSS plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/filter_pages.test.ts.snap
+++ b/tests/__snapshots__/filter_pages.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Filter pages (allow all) 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Filter pages (allow all) 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,
@@ -438,6 +448,11 @@ snapshot[`Filter pages (allow only /multiple/*) 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -445,6 +460,11 @@ snapshot[`Filter pages (allow only /multiple/*) 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/imagick.test.ts.snap
+++ b/tests/__snapshots__/imagick.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`imagick plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`imagick plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/inline.test.ts.snap
+++ b/tests/__snapshots__/inline.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`inline plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`inline plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/json.test.ts.snap
+++ b/tests/__snapshots__/json.test.ts.snap
@@ -1,0 +1,83 @@
+export const snapshot = {};
+
+snapshot[`JSON plugin 1`] = `
+{
+  formats: [
+    {
+      engines: 1,
+      ext: ".tmpl.ts",
+      pageLoader: [AsyncFunction: module],
+    },
+    {
+      engines: 1,
+      ext: ".tmpl.js",
+      pageLoader: [AsyncFunction: module],
+    },
+    {
+      engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
+      ext: ".tmpl.json",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
+    },
+    {
+      engines: 1,
+      ext: ".md",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      componentLoader: [AsyncFunction: module],
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".js",
+    },
+    {
+      componentLoader: [AsyncFunction: module],
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".ts",
+    },
+    {
+      componentLoader: [AsyncFunction: text],
+      engines: 1,
+      ext: ".njk",
+      includesPath: "_includes",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: undefined,
+      ext: ".yaml",
+      pageLoader: [AsyncFunction: yaml],
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: undefined,
+      ext: ".yml",
+      pageLoader: [AsyncFunction: yaml],
+    },
+  ],
+}
+`;
+
+snapshot[`JSON plugin 2`] = `[]`;
+
+snapshot[`JSON plugin 3`] = `[]`;

--- a/tests/__snapshots__/jsx.test.ts.snap
+++ b/tests/__snapshots__/jsx.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`build a site with jsx/tsx modules 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`build a site with jsx/tsx modules 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/jsx_preact.test.ts.snap
+++ b/tests/__snapshots__/jsx_preact.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`build a site with jsx/tsx modules using Preact 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`build a site with jsx/tsx modules using Preact 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/katex.test.ts.snap
+++ b/tests/__snapshots__/katex.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Katex plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Katex plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/lightningcss.test.ts.snap
+++ b/tests/__snapshots__/lightningcss.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`lightningcss plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`lightningcss plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,
@@ -165,6 +175,11 @@ snapshot[`lightningcss plugin (bundle mode) 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -172,6 +187,11 @@ snapshot[`lightningcss plugin (bundle mode) 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/liquid.test.ts.snap
+++ b/tests/__snapshots__/liquid.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`build a site with liquid 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`build a site with liquid 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/loaders.test.ts.snap
+++ b/tests/__snapshots__/loaders.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Load the pages of a site 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Load the pages of a site 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/markdown.test.ts.snap
+++ b/tests/__snapshots__/markdown.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Build a markdown site 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Build a markdown site 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,
@@ -565,6 +575,11 @@ snapshot[`Build a markdown with hooks 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -572,6 +587,11 @@ snapshot[`Build a markdown with hooks 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/mdx.test.ts.snap
+++ b/tests/__snapshots__/mdx.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Build a mdx site 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Build a mdx site 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/metas.test.ts.snap
+++ b/tests/__snapshots__/metas.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`metas plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`metas plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/minify_html.test.ts.snap
+++ b/tests/__snapshots__/minify_html.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`minify_html plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`minify_html plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/module.test.ts.snap
+++ b/tests/__snapshots__/module.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Build a site with js/ts modules 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Build a site with js/ts modules 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/multilanguage.test.ts.snap
+++ b/tests/__snapshots__/multilanguage.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`multilanguage plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`multilanguage plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/nav.test.ts.snap
+++ b/tests/__snapshots__/nav.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`nav plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`nav plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/netlify_cms.test.ts.snap
+++ b/tests/__snapshots__/netlify_cms.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`code_hightlight plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`code_hightlight plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/nunjucks.test.ts.snap
+++ b/tests/__snapshots__/nunjucks.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`build a site with nunjucks 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`build a site with nunjucks 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/pagefind.test.ts.snap
+++ b/tests/__snapshots__/pagefind.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Pagefind plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Pagefind plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/postcss.test.ts.snap
+++ b/tests/__snapshots__/postcss.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`postcss plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`postcss plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,
@@ -222,6 +232,11 @@ snapshot[`postcss plugin without includes 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -229,6 +244,11 @@ snapshot[`postcss plugin without includes 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,
@@ -391,6 +411,11 @@ snapshot[`postcss plugin with hooks 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -398,6 +423,11 @@ snapshot[`postcss plugin with hooks 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/pretty_urls.test.ts.snap
+++ b/tests/__snapshots__/pretty_urls.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Disabled pretty URLs 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Disabled pretty URLs 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/prism.test.ts.snap
+++ b/tests/__snapshots__/prism.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Prism plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Prism plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/pug.test.ts.snap
+++ b/tests/__snapshots__/pug.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`build a site with pug 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`build a site with pug 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/relations.test.ts.snap
+++ b/tests/__snapshots__/relations.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`relations plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`relations plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/relative_urls.test.ts.snap
+++ b/tests/__snapshots__/relative_urls.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`relative_url plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`relative_url plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/remark.test.ts.snap
+++ b/tests/__snapshots__/remark.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Build a markdown site 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Build a markdown site 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/remote_files.test.ts.snap
+++ b/tests/__snapshots__/remote_files.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`render remote files 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`render remote files 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/render_order.test.ts.snap
+++ b/tests/__snapshots__/render_order.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`render order property 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`render order property 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/resolve_urls.test.ts.snap
+++ b/tests/__snapshots__/resolve_urls.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`relative_url plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`relative_url plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/sass.test.ts.snap
+++ b/tests/__snapshots__/sass.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`sass plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`sass plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/sheets.test.ts.snap
+++ b/tests/__snapshots__/sheets.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Sheets plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Sheets plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/sitemap.test.ts.snap
+++ b/tests/__snapshots__/sitemap.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Sitemap plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Sitemap plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/slugify_urls.test.ts.snap
+++ b/tests/__snapshots__/slugify_urls.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`slugify_urls plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`slugify_urls plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/source_maps.test.ts.snap
+++ b/tests/__snapshots__/source_maps.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Source maps from CSS files 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Source maps from CSS files 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,
@@ -275,6 +285,11 @@ snapshot[`Source maps from Js files 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -282,6 +297,11 @@ snapshot[`Source maps from Js files 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/static_files.test.ts.snap
+++ b/tests/__snapshots__/static_files.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`Copy static files 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`Copy static files 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/svgo.test.ts.snap
+++ b/tests/__snapshots__/svgo.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`terser plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`terser plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/tailwindcss.test.ts.snap
+++ b/tests/__snapshots__/tailwindcss.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`postcss plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`postcss plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/terser.test.ts.snap
+++ b/tests/__snapshots__/terser.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`terser plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`terser plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/toml.test.ts.snap
+++ b/tests/__snapshots__/toml.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`TOML plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`TOML plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/url.test.ts.snap
+++ b/tests/__snapshots__/url.test.ts.snap
@@ -15,6 +15,11 @@ snapshot[`url and htmlUrl update href 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -22,6 +27,11 @@ snapshot[`url and htmlUrl update href 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,
@@ -244,6 +254,11 @@ snapshot[`configure url and htmlUrl names 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -251,6 +266,11 @@ snapshot[`configure url and htmlUrl names 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/__snapshots__/windi_css.test.ts.snap
+++ b/tests/__snapshots__/windi_css.test.ts.snap
@@ -21,6 +21,11 @@ snapshot[`Windi CSS plugin 1`] = `
     },
     {
       engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
       ext: ".tmpl.json",
       pageLoader: [AsyncFunction: json],
     },
@@ -28,6 +33,11 @@ snapshot[`Windi CSS plugin 1`] = `
       dataLoader: [AsyncFunction: json],
       engines: undefined,
       ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
     },
     {
       engines: 1,

--- a/tests/assets/json/_data.jsonc
+++ b/tests/assets/json/_data.jsonc
@@ -1,0 +1,6 @@
+{
+  "site": {
+    "title": "Default title", // comment
+    "description": "Default description" /* comment */
+  }
+}

--- a/tests/assets/json/_includes/layout.njk
+++ b/tests/assets/json/_includes/layout.njk
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <title>{{ title }}</title>
+  </head>
+  <body>
+    <h1>{{ site.title }}</h1>
+    <p>{{ site.description }}</p>
+    <h2>{{ title }}</h2>
+    <p>{{ content }}</p>
+    
+  </body>
+</html>

--- a/tests/assets/json/index.json
+++ b/tests/assets/json/index.json
@@ -1,0 +1,6 @@
+{
+  "title": "Title of the index",
+  "content": "Content of the index",
+  "date": "1979-06-21T23:45:00.000Z",
+  "layout": "layout.njk"
+}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -114,7 +114,7 @@ Deno.test("data configuration", () => {
   const site = lume();
   const { formats } = site;
 
-  equals(formats.size, 11);
+  equals(formats.size, 13);
   equals(formats.has(".json"), true);
   assert(formats.get(".json")?.dataLoader);
   equals(formats.has(".jsonc"), true);
@@ -131,7 +131,7 @@ Deno.test("data configuration", () => {
   const loader = () => Promise.resolve({});
   site.loadData([".ext1", ".ext2"], loader);
 
-  equals(formats.size, 13);
+  equals(formats.size, 15);
   equals(formats.get(".ext1")?.dataLoader, loader);
   equals(formats.get(".ext2")?.dataLoader, loader);
 });
@@ -140,7 +140,7 @@ Deno.test("pages configuration", () => {
   const site = lume();
   const { formats } = site;
 
-  equals(formats.size, 11);
+  equals(formats.size, 13);
 
   const extensions = [
     ".tmpl.json",
@@ -175,7 +175,7 @@ Deno.test("pages configuration", () => {
 
   site.loadPages(newExts, loader, engine);
 
-  equals(formats.size, 13);
+  equals(formats.size, 15);
 
   for (const ext of newExts) {
     equals(formats.has(ext), true);
@@ -188,7 +188,7 @@ Deno.test("assets configuration", () => {
   const site = lume();
   const { formats } = site;
 
-  equals(formats.size, 11);
+  equals(formats.size, 13);
 
   const loader = () => Promise.resolve({});
 
@@ -199,7 +199,7 @@ Deno.test("assets configuration", () => {
 
   site.loadAssets(extensions, loader);
 
-  equals(formats.size, 12);
+  equals(formats.size, 14);
   for (const ext of extensions) {
     equals(formats.has(ext), true);
     assert(formats.get(ext)?.pageLoader);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -117,6 +117,8 @@ Deno.test("data configuration", () => {
   equals(formats.size, 11);
   equals(formats.has(".json"), true);
   assert(formats.get(".json")?.dataLoader);
+  equals(formats.has(".jsonc"), true);
+  assert(formats.get(".jsonc")?.dataLoader);
   equals(formats.has(".js"), true);
   assert(formats.get(".js")?.dataLoader);
   equals(formats.has(".ts"), true);
@@ -142,6 +144,7 @@ Deno.test("pages configuration", () => {
 
   const extensions = [
     ".tmpl.json",
+    ".tmpl.jsonc",
     ".tmpl.js",
     ".tmpl.ts",
     ".md",

--- a/tests/json.test.ts
+++ b/tests/json.test.ts
@@ -1,0 +1,10 @@
+import { assertSiteSnapshot, build, getSite } from "./utils.ts";
+
+Deno.test("JSON plugin", async (t) => {
+  const site = getSite({
+    src: "json",
+  });
+
+  await build(site);
+  await assertSiteSnapshot(t, site);
+});


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

JSONC format support, reusing existing dependencies.
I tried to write some tests... But it seems that many runs fail

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
