### PR TITLE
esbuild plugins option does not work

### DIFF
--- a/plugins/esbuild.ts
+++ b/plugins/esbuild.ts
@@ -204,10 +204,10 @@ export default function (userOptions?: Partial<Options>) {
         });
       },
     };
-    options.options.plugins?.unshift(lumeLoaderPlugin);
+    options.options.plugins?.push(lumeLoaderPlugin);
 
     site.hooks.addEsbuildPlugin = (plugin) => {
-      options.options.plugins?.push(plugin);
+      options.options.plugins?.unshift(plugin);
     };
 
     /** Run esbuild and returns the output files */


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

esbuild plugin has `lumeLoaderPlugin`.
It works at first and catches all.
That means all other appended plugins are actually ignored.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
