### PR TITLE
Parameterize command for Netlify CMS proxy server in netlify_cms plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Any BREAKING CHANGE between minor versions will be documented here in upper case
     This ensure the plugin will works ofline, once the requests are cached.
   - Change the order of the custom plugins [#445]
 - Updated deps: `terser`, `std`, `preact`, `postcss`, `liquid`.
+- Add `proxyCommand` as option for `netlify_cms` plugin.
 
 ## [1.18.1] - 2023-07-05
 ### Fixed

--- a/plugins/netlify_cms.ts
+++ b/plugins/netlify_cms.ts
@@ -24,6 +24,9 @@ export interface Options {
 
   /** Custom HTML code to append in the index.html page */
   extraHTML: string;
+
+  /** Command to run the proxy server */
+  proxyCommand: string;
 }
 
 const defaults: Options = {
@@ -32,6 +35,7 @@ const defaults: Options = {
   configKey: "netlify_cms",
   netlifyIdentity: false,
   extraHTML: "",
+  proxyCommand: "npx netlify-cms-proxy-server",
 };
 
 /** A plugin to use Netlify CMS in Lume easily */
@@ -46,7 +50,7 @@ export default function (userOptions?: Partial<Options>) {
     // Run the local netlify server
     if (local_backend) {
       site.addEventListener("afterStartServer", () => {
-        site.run("npx netlify-cms-proxy-server");
+        site.run(options.proxyCommand);
       });
     }
 


### PR DESCRIPTION
## Description

I never want to have to install NPM just to run `netlify-cms-proxy-server` to use the netlify_cms plugin locally (I can install it via `deno install npm:netlify-cms-proxy-server` instead). Therefore I added a `proxyCommand` option for the `netlify_cms` plugin and set the default of the current command used (`npx netlify-cms-proxy-server`). It makes it overridable for people like me who want to be rid of NPM from my system entirely.

## Related Issues

N/A

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.

I did not see any tests for the `netlify_cms` plugin so I wasn't sure where to put such a test to check that overriding the `proxyCommand` option in `netlify_cms` plugin that it propagates appropriately. Feedback on where to add such a test is appreciated.

  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
