### PR TITLE
Relative URL Plugin Not Work when Pretty URL is disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project try to adheres to [Semantic Versioning](https://semver.org/),
 but not always is possible (due the use of unstable features from Deno).
 Any BREAKING CHANGE between minor versions will be documented here in upper case.
 
+## Unreleased
+
+### Fixed
+- `relative_urls` give wrong URL when `prettyUrls` is disabled
+
 ## [1.18.2] - 2023-07-21
 ### Added
 - `slugify_urls` plugin is applied also to static files [#447].

--- a/plugins/relative_urls.ts
+++ b/plugins/relative_urls.ts
@@ -19,7 +19,8 @@ export default function () {
         }
 
         const from = site.url(page.data.url as string);
-        return posix.relative(from, url);
+        if (site.options.prettyUrls) return posix.relative(from, url);
+        else return posix.relative(posix.dirname(from), url);
       },
     }));
   };

--- a/plugins/relative_urls.ts
+++ b/plugins/relative_urls.ts
@@ -20,7 +20,7 @@ export default function () {
 
         const from = site.url(page.data.url as string);
         if (site.options.prettyUrls) return posix.relative(from, url);
-        else return posix.relative(posix.dirname(from), url);
+        else return posix.join("./", posix.relative(posix.dirname(from), url));
       },
     }));
   };

--- a/tests/__snapshots__/relative_urls.test.ts.snap
+++ b/tests/__snapshots__/relative_urls.test.ts.snap
@@ -380,3 +380,384 @@ snapshot[`relative_url plugin 3`] = `
   },
 ]
 `;
+
+snapshot[`relative_url plugin when pretty urls disabled 1`] = `
+{
+  formats: [
+    {
+      engines: 1,
+      ext: ".tmpl.ts",
+      pageLoader: [AsyncFunction: module],
+    },
+    {
+      engines: 1,
+      ext: ".tmpl.js",
+      pageLoader: [AsyncFunction: module],
+    },
+    {
+      engines: undefined,
+      ext: ".tmpl.jsonc",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      engines: undefined,
+      ext: ".tmpl.json",
+      pageLoader: [AsyncFunction: json],
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".json",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: undefined,
+      ext: ".jsonc",
+    },
+    {
+      engines: 1,
+      ext: ".md",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      componentLoader: [AsyncFunction: module],
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".js",
+    },
+    {
+      componentLoader: [AsyncFunction: module],
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".ts",
+    },
+    {
+      componentLoader: [AsyncFunction: text],
+      engines: 1,
+      ext: ".njk",
+      includesPath: "_includes",
+      pageLoader: [AsyncFunction: text],
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: undefined,
+      ext: ".yaml",
+      pageLoader: [AsyncFunction: yaml],
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: undefined,
+      ext: ".yml",
+      pageLoader: [AsyncFunction: yaml],
+    },
+  ],
+  src: [
+    "/",
+    "/about-us",
+    "/about-us/contact.md",
+    "/about-us/index.md",
+    "/about-us/presentation.md",
+    "/index.md",
+  ],
+}
+`;
+
+snapshot[`relative_url plugin when pretty urls disabled 2`] = `[]`;
+
+snapshot[`relative_url plugin when pretty urls disabled 3`] = `
+[
+  {
+    content: "<!DOCTYPE html>
+" +
+      "<html><head></head><body><p>Contact</p>
+" +
+      "<ul>
+" +
+      '<li><a href="..">Index</a></li>
+' +
+      '<li><a href="./">About us</a></li>
+' +
+      '<li><a href="contact">Contact</a></li>
+' +
+      '<li><a href="presentation">Presentation</a></li>
+' +
+      "</ul>
+" +
+      "</body></html>",
+    data: {
+      children: "<p>Contact</p>
+" +
+        "<ul>
+" +
+        '<li><a href="/">Index</a></li>
+' +
+        '<li><a href="/about-us">About us</a></li>
+' +
+        '<li><a href="/about-us/contact">Contact</a></li>
+' +
+        '<li><a href="/about-us/presentation">Presentation</a></li>
+' +
+        "</ul>
+",
+      content: "Contact
+" +
+        "
+" +
+        "- [Index](/)
+" +
+        "- [About us](/about-us)
+" +
+        "- [Contact](/about-us/contact)
+" +
+        "- [Presentation](/about-us/presentation)
+",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      url: "/about-us/contact.html",
+    },
+    src: {
+      asset: undefined,
+      ext: ".md",
+      path: "/about-us/contact",
+      remote: undefined,
+      slug: "contact",
+    },
+  },
+  {
+    content: "<!DOCTYPE html>
+" +
+      "<html><head></head><body><p>About us</p>
+" +
+      "<ul>
+" +
+      '<li><a href="..">Index</a></li>
+' +
+      '<li><a href="./">About us</a></li>
+' +
+      '<li><a href="contact">Contact</a></li>
+' +
+      '<li><a href="presentation">Presentation</a></li>
+' +
+      "</ul>
+" +
+      "</body></html>",
+    data: {
+      children: "<p>About us</p>
+" +
+        "<ul>
+" +
+        '<li><a href="/">Index</a></li>
+' +
+        '<li><a href="/about-us">About us</a></li>
+' +
+        '<li><a href="/about-us/contact">Contact</a></li>
+' +
+        '<li><a href="/about-us/presentation">Presentation</a></li>
+' +
+        "</ul>
+",
+      content: "About us
+" +
+        "
+" +
+        "- [Index](/)
+" +
+        "- [About us](/about-us)
+" +
+        "- [Contact](/about-us/contact)
+" +
+        "- [Presentation](/about-us/presentation)
+",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      url: "/about-us/index.html",
+    },
+    src: {
+      asset: undefined,
+      ext: ".md",
+      path: "/about-us/index",
+      remote: undefined,
+      slug: "index",
+    },
+  },
+  {
+    content: "<!DOCTYPE html>
+" +
+      "<html><head></head><body><p>Presentation</p>
+" +
+      "<ul>
+" +
+      '<li><a href="..">Index</a></li>
+' +
+      '<li><a href="./">About us</a></li>
+' +
+      '<li><a href="contact">Contact</a></li>
+' +
+      '<li><a href="presentation">Presentation</a></li>
+' +
+      "</ul>
+" +
+      "</body></html>",
+    data: {
+      children: "<p>Presentation</p>
+" +
+        "<ul>
+" +
+        '<li><a href="/">Index</a></li>
+' +
+        '<li><a href="/about-us">About us</a></li>
+' +
+        '<li><a href="/about-us/contact">Contact</a></li>
+' +
+        '<li><a href="/about-us/presentation">Presentation</a></li>
+' +
+        "</ul>
+",
+      content: "Presentation
+" +
+        "
+" +
+        "- [Index](/)
+" +
+        "- [About us](/about-us)
+" +
+        "- [Contact](/about-us/contact)
+" +
+        "- [Presentation](/about-us/presentation)
+",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      url: "/about-us/presentation.html",
+    },
+    src: {
+      asset: undefined,
+      ext: ".md",
+      path: "/about-us/presentation",
+      remote: undefined,
+      slug: "presentation",
+    },
+  },
+  {
+    content: "<!DOCTYPE html>
+" +
+      "<html><head></head><body><p>Index</p>
+" +
+      "<ul>
+" +
+      '<li><a href="./">Index</a></li>
+' +
+      '<li><a href="about-us">About us</a></li>
+' +
+      '<li><a href="./about-us/contact">Contact</a></li>
+' +
+      '<li><a href="about-us/presentation">Presentation</a></li>
+' +
+      '<li><a href="?ignored=true">Ignored</a></li>
+' +
+      '<li><a href="#ignored">Ignored</a></li>
+' +
+      '<li><a href="https://ignored.com">Ignored</a></li>
+' +
+      '<li><a href="//ignored.com">Ignored</a></li>
+' +
+      "</ul>
+" +
+      "</body></html>",
+    data: {
+      children: "<p>Index</p>
+" +
+        "<ul>
+" +
+        '<li><a href="/">Index</a></li>
+' +
+        '<li><a href="about-us">About us</a></li>
+' +
+        '<li><a href="./about-us/contact">Contact</a></li>
+' +
+        '<li><a href="about-us/presentation">Presentation</a></li>
+' +
+        '<li><a href="?ignored=true">Ignored</a></li>
+' +
+        '<li><a href="#ignored">Ignored</a></li>
+' +
+        '<li><a href="https://ignored.com">Ignored</a></li>
+' +
+        '<li><a href="//ignored.com">Ignored</a></li>
+' +
+        "</ul>
+",
+      content: "Index
+" +
+        "
+" +
+        "- [Index](/)
+" +
+        "- [About us](about-us)
+" +
+        "- [Contact](./about-us/contact)
+" +
+        "- [Presentation](about-us/presentation)
+" +
+        "- [Ignored](?ignored=true)
+" +
+        "- [Ignored](#ignored)
+" +
+        "- [Ignored](https://ignored.com)
+" +
+        "- [Ignored](//ignored.com)
+",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      url: "/index.html",
+    },
+    src: {
+      asset: undefined,
+      ext: ".md",
+      path: "/index",
+      remote: undefined,
+      slug: "index",
+    },
+  },
+]
+`;

--- a/tests/relative_urls.test.ts
+++ b/tests/relative_urls.test.ts
@@ -12,3 +12,16 @@ Deno.test("relative_url plugin", async (t) => {
   await build(site);
   await assertSiteSnapshot(t, site);
 });
+
+Deno.test("relative_url plugin when pretty urls disabled", async (t) => {
+  const site = getSite({
+    src: "relative_urls",
+    location: new URL("https://example.com/blog"),
+    prettyUrls: false,
+  });
+
+  site.use(relativeUrls());
+
+  await build(site);
+  await assertSiteSnapshot(t, site);
+});


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Relative URL plugin give wrong path when pretty URL is disabled. URL are always start with `../`. For example when page is at `/index.md` and url is `/styles.css`, resolved url is `../styles.css`.

## Related Issues

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
