### PR TITLE
fix: use `/usr/bin/env bash` instead of `/bin/bash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Any BREAKING CHANGE between minor versions will be documented here in upper case
 
 ### Fixed
 - Updated dependencies: `std`, `@types/react`, `esbuild`, `postcss-nesting`, `vento`.
+- Script runner now uses `/usr/bin/env bash` instead of `/bin/bash` to improve portability.
 
 ## [1.18.4] - 2023-08-02
 ### Added

--- a/core/scripts.ts
+++ b/core/scripts.ts
@@ -101,7 +101,7 @@ export default class Scripts {
 function shArgs(script: string) {
   return Deno.build.os === "windows"
     ? ["PowerShell.exe", "-Command", script]
-    : ["/bin/bash", "-c", script];
+    : ["/usr/bin/env", "bash", "-c", script];
 }
 
 /** A script or function */


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Fixes `error: Uncaught NotFound: Failed to spawn: /bin/bash: No such file or directory (os error 2)` in Linux environments like NixOS that don't have `/bin/bash`.

## Related Issues

N/A

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
