### PR TITLE
feat(picture): support `sizes` attribute

### DIFF
--- a/plugins/picture.ts
+++ b/plugins/picture.ts
@@ -90,23 +90,35 @@ export default function (): Plugin {
       basePath: string,
     ) {
       const src = img.getAttribute("src") as string;
+      const sizes = img.getAttribute("sizes");
       const sourceFormats = saveTransform(basePath, src, imagick);
 
       for (const sourceFormat of sourceFormats) {
-        const source = createSource(img.ownerDocument!, src, sourceFormat);
+        const source = createSource(
+          img.ownerDocument!,
+          src,
+          sourceFormat,
+          sizes,
+        );
         picture.insertBefore(source, img);
       }
     }
 
     function handleImg(imagick: string, img: Element, basePath: string) {
       const src = img.getAttribute("src") as string;
+      const sizes = img.getAttribute("sizes");
       const sourceFormats = saveTransform(basePath, src, imagick);
       const picture = img.ownerDocument!.createElement("picture");
 
       img.replaceWith(picture);
 
       for (const sourceFormat of sourceFormats) {
-        const source = createSource(img.ownerDocument!, src, sourceFormat);
+        const source = createSource(
+          img.ownerDocument!,
+          src,
+          sourceFormat,
+          sizes,
+        );
         picture.append(source);
       }
 
@@ -194,19 +206,25 @@ function createSource(
   document: Document,
   src: string,
   srcFormat: SourceFormat,
+  sizes?: string | null | undefined,
 ) {
   const source = document.createElement("source");
-  const { scales, format } = srcFormat;
+  const { scales, format, width } = srcFormat;
   const path = encodeURI(getPathAndExtension(src)[0]);
   const srcset: string[] = [];
 
   for (const [suffix, scale] of Object.entries(scales)) {
-    const scaleSuffix = scale === 1 ? "" : ` ${scale}x`;
+    const scaleSuffix = ` ${scale * width}w`;
     srcset.push(`${path}${suffix}.${format}${scaleSuffix}`);
   }
 
   source.setAttribute("srcset", srcset.join(", "));
   source.setAttribute("type", typeByExtension(format));
+
+  if (sizes) {
+    source.setAttribute("sizes", sizes);
+  }
+
   return source;
 }
 

--- a/tests/__snapshots__/picture.test.ts.snap
+++ b/tests/__snapshots__/picture.test.ts.snap
@@ -113,16 +113,16 @@ snapshot[`imagick plugin 3`] = `
 
 <body>
   <div>
-    <picture><source srcset="/kevin%20schmid%20unsplash-600w.png, /kevin%20schmid%20unsplash-600w@2.png 2x" type="image/png"><img src="/kevin schmid unsplash.jpg"></picture>
+    <picture><source srcset="/kevin%20schmid%20unsplash-600w.png 600w, /kevin%20schmid%20unsplash-600w@2.png 1200w" type="image/png"><img src="/kevin schmid unsplash.jpg"></picture>
   </div>
 
 
   <picture>
-    <source srcset="/kevin%20schmid%20unsplash-600w.avif, /kevin%20schmid%20unsplash-600w@2.avif 2x" type="image/avif"><source srcset="/kevin%20schmid%20unsplash-600w.webp, /kevin%20schmid%20unsplash-600w@2.webp 2x" type="image/webp"><source srcset="/kevin%20schmid%20unsplash-600w.jpg, /kevin%20schmid%20unsplash-600w@2.jpg 2x" type="image/jpeg"><img src="/kevin schmid unsplash.jpg">
+    <source srcset="/kevin%20schmid%20unsplash-600w.avif 600w, /kevin%20schmid%20unsplash-600w@2.avif 1200w" type="image/avif"><source srcset="/kevin%20schmid%20unsplash-600w.webp 600w, /kevin%20schmid%20unsplash-600w@2.webp 1200w" type="image/webp"><source srcset="/kevin%20schmid%20unsplash-600w.jpg 600w, /kevin%20schmid%20unsplash-600w@2.jpg 1200w" type="image/jpeg"><img src="/kevin schmid unsplash.jpg">
   </picture>
 
   <!-- This image will be converted to a picture -->
-  <picture><source srcset="/kevin%20schmid%20unsplash-300w.avif, /kevin%20schmid%20unsplash-300w@2.avif 2x" type="image/avif"><source srcset="/kevin%20schmid%20unsplash-300w.webp, /kevin%20schmid%20unsplash-300w@2.webp 2x" type="image/webp"><source srcset="/kevin%20schmid%20unsplash-300w.jpg, /kevin%20schmid%20unsplash-300w@2.jpg 2x" type="image/jpeg"><img src="/kevin schmid unsplash.jpg"></picture>
+  <picture><source srcset="/kevin%20schmid%20unsplash-300w.avif 300w, /kevin%20schmid%20unsplash-300w@2.avif 600w" type="image/avif"><source srcset="/kevin%20schmid%20unsplash-300w.webp 300w, /kevin%20schmid%20unsplash-300w@2.webp 600w" type="image/webp"><source srcset="/kevin%20schmid%20unsplash-300w.jpg 300w, /kevin%20schmid%20unsplash-300w@2.jpg 600w" type="image/jpeg"><img src="/kevin schmid unsplash.jpg"></picture>
 
 
 </body></html>',


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Add support for responsive images generated by `picture` plugin.

1. Width dimension descriptors are provided instead of pixel ratio values (`200w` instead of `2x` for example).
2. `sizes` attribute preserved and passed for all `sources`

Source code:
```html
<img src="img.png" imagick="100@2" sizes="(width < 700px) 100px, 200px"/>
```

Before this change:
```html
<picture>
	<source srcset="img-100w.png, img-100w@2.png 2x"/>
	<img src="img.png" />
</picture>
```


After this change:
```html
<picture>
	<source srcset="img-100w.png 100w, img-100w@2.png 200w"  sizes="(width < 700px) 100px, 200px"/>
	<img src="img.png" />
</picture>
```

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
