### PR TITLE
feat(metas.ts): Simplify Twitter Card Tags

### DIFF
--- a/plugins/metas.ts
+++ b/plugins/metas.ts
@@ -107,15 +107,12 @@ export default function (userOptions?: Partial<Options>) {
       addMeta(document, "property", "og:image", image || icon);
 
       // Twitter cards
-      addMeta(document, "name", "twitter:title", title, 65);
-      addMeta(document, "name", "twitter:description", description, 200);
       addMeta(
         document,
         "name",
         "twitter:card",
         image ? "summary_large_image" : "summary",
       );
-      addMeta(document, "name", "twitter:image", image || icon);
       addMeta(document, "name", "twitter:site", twitter);
 
       // Schema.org


### PR DESCRIPTION
## Description

This commit optimizes the  plugin by simplifying the Twitter Card tags (`twitter:*`) when OpenGraph tags (`og:*`) are present, eliminating the need for redundant tags.

Changes Made:
- Removed `twitter:title` tag when `og:title` is present.
- Removed `twitter:image` tag when `og:image` is present.
- Removed `twitter:description` tag when `og:description` is present.
- Simplified Twitter Card tags to include only  and  when  tags are present.

## Related Issues

Related to #487 

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
