### PR TITLE
refactor(server): use `Deno.serve()`

### DIFF
--- a/cli/build.ts
+++ b/cli/build.ts
@@ -86,7 +86,7 @@ export async function build(
 
   // Start the local server
   const { port, open, page404, middlewares } = site.options.server;
-  const server = new Server({ root: site.dest() });
+  const server = new Server({ root: site.dest(), port });
 
   server.addEventListener("start", () => {
     const ipAddr = localIp();
@@ -138,7 +138,7 @@ export async function build(
     server.use(...middlewares);
   }
 
-  server.start({ port });
+  server.start();
 }
 
 function localIp(): string | undefined {

--- a/cli/build.ts
+++ b/cli/build.ts
@@ -86,7 +86,7 @@ export async function build(
 
   // Start the local server
   const { port, open, page404, middlewares } = site.options.server;
-  const server = new Server({ root: site.dest(), port });
+  const server = new Server({ root: site.dest() });
 
   server.addEventListener("start", () => {
     const ipAddr = localIp();
@@ -138,7 +138,7 @@ export async function build(
     server.use(...middlewares);
   }
 
-  await server.start();
+  server.start({ port });
 }
 
 function localIp(): string | undefined {

--- a/core/server.ts
+++ b/core/server.ts
@@ -55,8 +55,7 @@ export default class Server {
   use(...middleware: Middleware[]) {
     this.middlewares.push(...middleware);
     return this;
-  };
-
+  }
 
   /** Add a listener to an event */
   addEventListener(
@@ -77,7 +76,7 @@ export default class Server {
   start(options: Deno.ServeOptions = { port: 8000 }) {
     this.#server = Deno.serve(options, this.handle);
     this.dispatchEvent({ type: "start" });
-  };
+  }
 
   /** Stops the server */
   stop() {
@@ -92,7 +91,10 @@ export default class Server {
   }
 
   /** Handle a http request event */
-  async handle(request: Request, info: Deno.ServeHandlerInfo): Promise<Response> {
+  async handle(
+    request: Request,
+    info: Deno.ServeHandlerInfo,
+  ): Promise<Response> {
     const middlewares = [...this.middlewares];
 
     const next: RequestHandler = async (
@@ -108,7 +110,7 @@ export default class Server {
     };
 
     return await next(request);
-  };
+  }
 }
 
 /** Server a static file */

--- a/core/server.ts
+++ b/core/server.ts
@@ -8,13 +8,14 @@ import { serveFile as HttpServeFile } from "../deps/http.ts";
 import type { Event, EventListener, EventOptions } from "../core.ts";
 
 /** The options to configure the local server */
-export interface Options {
+export interface Options extends Deno.ServeOptions {
   /** The root path */
   root: string;
 }
 
 export const defaults: Options = {
   root: `${Deno.cwd()}/_site`,
+  port: 8000,
 };
 
 export type RequestHandler = (req: Request) => Promise<Response>;
@@ -73,9 +74,12 @@ export default class Server {
   }
 
   /** Start the server */
-  start(options: Deno.ServeOptions = { port: 8000 }) {
-    this.#server = Deno.serve(options, this.handle);
-    this.dispatchEvent({ type: "start" });
+  start(signal?: Deno.ServeOptions["signal"]) {
+    this.#server = Deno.serve({
+      ...this.options,
+      signal,
+      onListen: () => this.dispatchEvent({ type: "start" }),
+    }, this.handle);
   }
 
   /** Stops the server */

--- a/deps/http.ts
+++ b/deps/http.ts
@@ -1,4 +1,1 @@
 export { serveFile } from "https://deno.land/std@0.204.0/http/file_server.ts";
-export { Server } from "https://deno.land/std@0.204.0/http/server.ts";
-
-export type { ConnInfo } from "https://deno.land/std@0.204.0/http/server.ts";


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

A refactoring of Lume Server that uses the new `Deno.serve()` to simplify structure and improve performance.

> I'm not quite sure how to write a changelog for v2 at the moment, so I left it out.

```diff
import Server from "https:/deno.land/x/lume/core/server.ts";

const server = new Server({
  port: 8000,
  root: `${Deno.cwd()}/_site`,
});

- await server.start();
+ server.start();
+ // optional: Deno.serve({ port: 8000 }, server.handle)

console.log("Listening on http://localhost:8000");
```

It's worth noting that Middleware's `ConnInfo` has changed to `Deno.ServeHandlerInfo`.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
