### PR TITLE
update server types

### DIFF
--- a/core/server.ts
+++ b/core/server.ts
@@ -46,7 +46,7 @@ export default class Server {
   events: Events<ServerEvent> = new Events<ServerEvent>();
   options: Options;
   middlewares: Middleware[] = [];
-  #server?: Deno.Server;
+  #server?: Deno.HttpServer;
 
   constructor(options: Partial<Options> = {}) {
     this.options = { ...defaults, ...options };


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

in Deno 1.38, `Deno.serve()` now returns a `Deno.HttpServer` instead of `Deno.Server`.

https://deno.com/blog/v1.38#denoserve

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
