### PR TITLE
fix duplication bug in fixPluginOrder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Any BREAKING CHANGE between minor versions will be documented here in upper case
 ### Fixed
 - Tailwind: Fix types for `options`.
 - Favicon: Better error if the source file is missing [#504].
+- A bug in fixPluginOrder that duplicated plugins in the config file [#514].
 
 ## [1.19.3] - 2023-10-29
 ### Changed

--- a/init.ts
+++ b/init.ts
@@ -215,10 +215,14 @@ function fixPluginOrder(plugins: string[], plugin1: string, plugin2: string) {
     const pos1 = plugins.indexOf(plugin1);
     const pos2 = plugins.indexOf(plugin2);
 
-    if (pos2 !== -1) {
-      plugins.splice(pos2, 1);
+    if (pos2 === -1) {
+      plugins.splice(pos1 + 1, 0, plugin2);
+      return;
     }
 
-    plugins.splice(pos1, 1, plugin1, plugin2);
+    if (pos1 > pos2) {
+      plugins[pos2] = plugin1;
+      plugins[pos1] = plugin2;
+    }
   }
 }


### PR DESCRIPTION
fixPluginOrder would duplicate the entry for "plugin1" when "plugin2" was also provided. This has been fixed

## Description

Fixes a bug where the fixPluginOrder function would duplicate plugin1

## Related Issues

Fixes #514 

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
