### PR TITLE
Add configuration passthrough for remark-rehype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project try to adheres to [Semantic Versioning](https://semver.org/),
 but not always is possible (due the use of unstable features from Deno).
 Any BREAKING CHANGE between minor versions will be documented here in upper case.
 
-## [1.19.4] - Unreleased
+## [1.19.5]
+### Added
+- `remark` plugin: Support for passing custom configuration through to `remark-rehype`
+
+## [1.19.4] - 2023-11-29
 ### Fixed
 - Tailwind: Fix types for `options`.
 - Favicon: Better error if the source file is missing [#504].

--- a/plugins/remark.ts
+++ b/plugins/remark.ts
@@ -27,6 +27,9 @@ export interface Options {
   /** List of rehype plugins to use */
   rehypePlugins?: unknown[];
 
+  /** Configuration for remark-rehype */
+  remarkRehype?: object;
+
   /** Flag to turn on HTML sanitization to prevent XSS */
   sanitize?: boolean;
 
@@ -38,6 +41,7 @@ export interface Options {
 export const defaults: Options = {
   extensions: [".md"],
   sanitize: false,
+  remarkRehype: { allowDangerousHtml: true },
   useDefaultPlugins: true,
 };
 
@@ -106,7 +110,7 @@ export default function (userOptions?: Options) {
     plugins.push(...options.remarkPlugins);
 
     // Add remark-rehype to generate HAST
-    plugins.push([remarkRehype, { allowDangerousHtml: true }]);
+    plugins.push([remarkRehype, options.remarkRehype]);
 
     if (options.sanitize) {
       // Add rehype-raw to convert raw HTML to HAST


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

This change adds the ability to pass configuration from `_config.ts` down to `remark-rehype`.

It can be useful for users who need to customise how footnotes are rendered for Markdown files (such as when using [Littlefoot](https://littlefoot.js.org/) as well as a few other things should they be needed.

## Related Issues

Implements https://github.com/lumeland/lume/issues/517

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
