### PR TITLE
add log msg on missing Site instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project try to adheres to [Semantic Versioning](https://semver.org/).
 Go to the `v1` branch to see the changelog of Lume 1.
 
 ## [2.0.3] - Unreleased
+### Added
+- add critical log on rare case where developer forget to export the Site instance in the `_config.ts`
+
 ### Changed
 - `decap_cms` plugin: Add a script in the homepage to redirect to /admin/
   when an invite token or recovery token is detected from netlify identity.

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -48,6 +48,12 @@ export async function createSite(config?: string): Promise<Site> {
   if (url) {
     log.info(`Loading config file <dim>${url}</dim>`);
     const mod = await import(url);
+    if (!mod.default) {
+      log.critical(
+        `[Lume] Missing Site instance! Ensure your config file does export the Site instance as default.`,
+      );
+      throw new Error("Site instance is not found");
+    }
     return mod.default;
   }
 


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Adding critical log msg on missing site instance helps people who create `_config.ts` manually avoid silly accident of forgetting export the Site instance. While this is a rare case, it will surely suprise people once it happens (because it is pretty rare). I hope with this PR will improve developer experience on Lume.


**HOLD ON!**

This PR still has one problem which is I don't know what is suitable color to highlight key note. For now, I use cyan color, but I would like to have @oscarotero opinion about this.


## Related Issues

none

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
