### PR TITLE
Allow to use this in the filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 - Removed unused `imagick` dependency.
 - Added `Lume.PaginateResult` type.
 - Apply merge data strategies between multiple _data files/folders in the same folder.
-- Updated dependencies: `std`, `date-fns`, `esbuild`, `liquid`, `postcssNesting`, `react-dom` types, `sharp`, `svgo`, `vento`.
+- Updated dependencies: `std`, `date-fns`, `esbuild`, `liquid`, `postcssNesting`, `react-dom` types, `sharp`, `svgo`, `vento`, `tailwindcss`.
 
 ## [2.0.1] - 2023-12-10
 ### Added

--- a/core/renderer.ts
+++ b/core/renderer.ts
@@ -356,8 +356,11 @@ export interface Engine<T = string | { toString(): string }> {
 }
 
 /** A generic helper to be used in template engines */
+export interface HelperThis {
+  data: Data;
+}
 // deno-lint-ignore no-explicit-any
-export type Helper = (...args: any[]) => any;
+export type Helper = (this: HelperThis, ...args: any[]) => any;
 
 /** The options for a template helper */
 export interface HelperOptions {

--- a/core/renderer.ts
+++ b/core/renderer.ts
@@ -359,8 +359,9 @@ export interface Engine<T = string | { toString(): string }> {
 export interface HelperThis {
   data: Data;
 }
+
 // deno-lint-ignore no-explicit-any
-export type Helper = (this: HelperThis, ...args: any[]) => any;
+export type Helper = (this: HelperThis | void, ...args: any[]) => any;
 
 /** The options for a template helper */
 export interface HelperOptions {

--- a/deps/assert.ts
+++ b/deps/assert.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/assert/mod.ts";
+export * from "https://deno.land/std@0.210.0/assert/mod.ts";

--- a/deps/base64.ts
+++ b/deps/base64.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/encoding/base64.ts";
+export * from "https://deno.land/std@0.210.0/encoding/base64.ts";

--- a/deps/cli.ts
+++ b/deps/cli.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/cli/mod.ts";
+export * from "https://deno.land/std@0.210.0/cli/mod.ts";

--- a/deps/colors.ts
+++ b/deps/colors.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/fmt/colors.ts";
+export * from "https://deno.land/std@0.210.0/fmt/colors.ts";

--- a/deps/crypto.ts
+++ b/deps/crypto.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/crypto/mod.ts";
+export * from "https://deno.land/std@0.210.0/crypto/mod.ts";

--- a/deps/front_matter.ts
+++ b/deps/front_matter.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/front_matter/any.ts";
+export * from "https://deno.land/std@0.210.0/front_matter/any.ts";

--- a/deps/fs.ts
+++ b/deps/fs.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/fs/mod.ts";
+export * from "https://deno.land/std@0.210.0/fs/mod.ts";

--- a/deps/hex.ts
+++ b/deps/hex.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/encoding/hex.ts";
+export * from "https://deno.land/std@0.210.0/encoding/hex.ts";

--- a/deps/http.ts
+++ b/deps/http.ts
@@ -1,1 +1,1 @@
-export { serveFile } from "https://deno.land/std@0.209.0/http/file_server.ts";
+export { serveFile } from "https://deno.land/std@0.210.0/http/file_server.ts";

--- a/deps/jsonc.ts
+++ b/deps/jsonc.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/jsonc/mod.ts";
+export * from "https://deno.land/std@0.210.0/jsonc/mod.ts";

--- a/deps/log.ts
+++ b/deps/log.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/log/mod.ts";
+export * from "https://deno.land/std@0.210.0/log/mod.ts";

--- a/deps/media_types.ts
+++ b/deps/media_types.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/media_types/mod.ts";
+export * from "https://deno.land/std@0.210.0/media_types/mod.ts";

--- a/deps/path.ts
+++ b/deps/path.ts
@@ -1,2 +1,2 @@
-export * from "https://deno.land/std@0.209.0/path/mod.ts";
-export * as posix from "https://deno.land/std@0.209.0/path/posix/mod.ts";
+export * from "https://deno.land/std@0.210.0/path/mod.ts";
+export * as posix from "https://deno.land/std@0.210.0/path/posix/mod.ts";

--- a/deps/snapshot.ts
+++ b/deps/snapshot.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/testing/snapshot.ts";
+export * from "https://deno.land/std@0.210.0/testing/snapshot.ts";

--- a/deps/tailwindcss.ts
+++ b/deps/tailwindcss.ts
@@ -1,2 +1,2 @@
-export { default } from "npm:tailwindcss@3.3.6";
-export type { Config } from "npm:tailwindcss@3.3.6";
+export { default } from "npm:tailwindcss@3.4.0";
+export type { Config } from "npm:tailwindcss@3.4.0";

--- a/deps/toml.ts
+++ b/deps/toml.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/toml/mod.ts";
+export * from "https://deno.land/std@0.210.0/toml/mod.ts";

--- a/deps/vento.ts
+++ b/deps/vento.ts
@@ -1,5 +1,5 @@
-export { default as engine } from "https://deno.land/x/vento@v0.9.2/mod.ts";
-export { FileLoader } from "https://deno.land/x/vento@v0.9.2/src/loader.ts";
+export { default as engine } from "https://deno.land/x/vento@v0.10.0/mod.ts";
+export { FileLoader } from "https://deno.land/x/vento@v0.10.0/src/loader.ts";
 
-export type { Environment } from "https://deno.land/x/vento@v0.9.2/src/environment.ts";
-export type { Token } from "https://deno.land/x/vento@v0.9.2/src/tokenizer.ts";
+export type { Environment } from "https://deno.land/x/vento@v0.10.0/src/environment.ts";
+export type { Token } from "https://deno.land/x/vento@v0.10.0/src/tokenizer.ts";

--- a/deps/yaml.ts
+++ b/deps/yaml.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.209.0/yaml/mod.ts";
+export * from "https://deno.land/std@0.210.0/yaml/mod.ts";

--- a/plugins/nunjucks.ts
+++ b/plugins/nunjucks.ts
@@ -5,12 +5,7 @@ import { normalizePath, resolveInclude } from "../core/utils/path.ts";
 import { basename, join, posix } from "../deps/path.ts";
 
 import type Site from "../core/site.ts";
-import type {
-  Engine,
-  Helper,
-  HelperOptions,
-  HelperThis,
-} from "../core/renderer.ts";
+import type { Engine, Helper, HelperOptions } from "../core/renderer.ts";
 import type { ProxyComponents } from "../core/source.ts";
 
 export interface Options {
@@ -145,6 +140,7 @@ export class NunjucksEngine implements Engine {
           return;
         }
 
+        // deno-lint-ignore no-explicit-any
         this.env.addFilter(name, function (this: any, ...args: unknown[]) {
           return fn.apply({ data: this.ctx }, args);
         });
@@ -281,6 +277,7 @@ export default function (userOptions?: Options) {
  * https://mozilla.github.io/nunjucks/api.html#custom-filters
  */
 function createAsyncFilter(fn: Helper) {
+  // deno-lint-ignore no-explicit-any
   return async function (this: any, ...args: unknown[]) {
     const cb = args.pop() as (err: unknown, result?: unknown) => void;
 
@@ -330,8 +327,8 @@ function createCustomTag(name: string, fn: Helper, options: HelperOptions) {
       return new nodes.CallExtension(tagExtension, "run", args, extraArgs);
     },
 
-    // @ts-ignore: There's no types for Nunjucks
-    run(context: any, ...args) {
+    // deno-lint-ignore no-explicit-any
+    run(context: any, ...args: any[]) {
       if (options.body) {
         const [body] = args.splice(
           options.async ? args.length - 2 : args.length - 1,

--- a/plugins/pug.ts
+++ b/plugins/pug.ts
@@ -102,7 +102,10 @@ export class PugEngine implements Engine {
       case "filter": {
         this.options.filters ||= {};
 
-        const filter: Helper = (text: string, opt: Record<string, unknown>) => {
+        const filter: Helper = function (
+          text: string,
+          opt: Record<string, unknown>,
+        ) {
           delete opt.filename;
           const args = Object.values(opt);
           return fn(text, ...args);

--- a/plugins/vento.ts
+++ b/plugins/vento.ts
@@ -4,6 +4,7 @@ import { merge } from "../core/utils/object.ts";
 import { normalizePath } from "../core/utils/path.ts";
 
 import type Site from "../core/site.ts";
+import type { Data } from "../core/file.ts";
 import type { Engine, Helper } from "../core/renderer.ts";
 import type FS from "../core/fs.ts";
 import type { Environment, Token } from "../deps/vento.ts";
@@ -100,7 +101,9 @@ export class VentoEngine implements Engine {
   }
 
   addHelper(name: string, fn: Helper) {
-    this.engine.filters[name] = fn;
+    this.engine.filters[name] = function (...args: unknown[]) {
+      return fn.apply({ data: this.data as Data }, args);
+    };
   }
 }
 

--- a/tests/__snapshots__/liquid.test.ts.snap
+++ b/tests/__snapshots__/liquid.test.ts.snap
@@ -264,6 +264,10 @@ snapshot[`build a site with liquid 3`] = `
   <li>This is a partial</li>
   <li>async helper in a partial (async)</li>
 </ul>
+
+<strong>The title</strong>
+<strong>The title</strong>
+<p><strong>The title</strong></p>
 </main>
   </body>
 </html>
@@ -288,6 +292,10 @@ snapshot[`build a site with liquid 3`] = `
   <li>This is a partial</li>
   <li>async helper in a partial (async)</li>
 </ul>
+
+<strong>The title</strong>
+<strong>The title</strong>
+<p><strong>The title</strong></p>
 ",
       content: '<p>{% upperCase title %}</p>
 <p>{% upperCase "The title" %}</p>
@@ -301,6 +309,10 @@ snapshot[`build a site with liquid 3`] = `
 
 {% include "partial.liquid" %}
 {% include "./_includes/partial.liquid" %}
+
+<strong>{{ "title" | fromPage }}</strong>
+<strong>{{ "title" | fromPageAsync }}</strong>
+<p>{% fromPageTagAsync %}title{% endfromPageTagAsync %}</p>
 ',
       date: [],
       layout: "basic.liquid",

--- a/tests/__snapshots__/nunjucks.test.ts.snap
+++ b/tests/__snapshots__/nunjucks.test.ts.snap
@@ -428,7 +428,10 @@ console.log("Hello world, from the icon/User component");
   <li>This is a partial</li>
   <li>async helper in a partial (async)</li>
 </ul>
-</main>
+
+<strong>The title</strong>
+<strong>The title</strong>
+<p><strong>The title</strong></p></main>
   </body>
 </html>
 ',
@@ -452,7 +455,10 @@ console.log("Hello world, from the icon/User component");
   <li>This is a partial</li>
   <li>async helper in a partial (async)</li>
 </ul>
-",
+
+<strong>The title</strong>
+<strong>The title</strong>
+<p><strong>The title</strong></p>",
       comp: [
         "_components",
         "_proxies",
@@ -469,7 +475,10 @@ console.log("Hello world, from the icon/User component");
 
 {% include "partial.njk" %}
 {% include "./_includes/partial.njk" %}
-',
+
+<strong>{{ "title" | fromPage }}</strong>
+<strong>{{ "title" | fromPageAsync }}</strong>
+<p>{% fromPageTagAsync %}title{% endfromPageTagAsync %}</p>',
       date: [],
       layout: "basic.njk",
       mergedKeys: [

--- a/tests/__snapshots__/tailwindcss.test.ts.snap
+++ b/tests/__snapshots__/tailwindcss.test.ts.snap
@@ -969,7 +969,7 @@ snapshot[`postcss plugin 3`] = `
   },
   {
     content: "/*
-! tailwindcss v3.3.6 | MIT License | https://tailwindcss.com
+! tailwindcss v3.4.0 | MIT License | https://tailwindcss.com
 *//*
 1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
 2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
@@ -996,17 +996,20 @@ snapshot[`postcss plugin 3`] = `
 4. Use the user's configured \`sans\` font-family by default.
 5. Use the user's configured \`sans\` font-feature-settings by default.
 6. Use the user's configured \`sans\` font-variation-settings by default.
+7. Disable tap highlights on iOS
 */
 
-html {
+html,
+:host {
   line-height: 1.5; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
   -moz-tab-size: 4; /* 3 */
   -o-tab-size: 4;
      tab-size: 4; /* 3 */
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, \\"Helvetica Neue\\", Arial, \\"Noto Sans\\", sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\", \\"Noto Color Emoji\\"; /* 4 */
+  font-family: ui-sans-serif, system-ui, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\", \\"Noto Color Emoji\\"; /* 4 */
   font-feature-settings: normal; /* 5 */
   font-variation-settings: normal; /* 6 */
+  -webkit-tap-highlight-color: transparent; /* 7 */
 }
 
 /*
@@ -1753,7 +1756,7 @@ video {
   text-align: justify;
 }
 .font-sans {
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, \\"Helvetica Neue\\", Arial, \\"Noto Sans\\", sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\", \\"Noto Color Emoji\\";
+  font-family: ui-sans-serif, system-ui, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\", \\"Noto Color Emoji\\";
 }
 .text-2xl {
   font-size: 1.5rem;

--- a/tests/__snapshots__/vento.test.ts.snap
+++ b/tests/__snapshots__/vento.test.ts.snap
@@ -143,6 +143,9 @@ snapshot[`build a site with vento 3`] = `
 
 CUSTOM FILTER
 
+<strong>Título</strong>
+<strong>Título</strong>
+
 
   <footer>
 Título
@@ -165,6 +168,9 @@ Título
 
 
 CUSTOM FILTER
+
+<strong>Título</strong>
+<strong>Título</strong>
 ',
       comp: [
         "_components",
@@ -181,6 +187,9 @@ CUSTOM FILTER
 {{ comp button {href, content: "Go to Lume"} /}}
 
 {{ "custom filter" |> upper }}
+
+<strong>{{ "title" |> fromPage }}</strong>
+<strong>{{ "title" |> await fromPageAsync }}</strong>
 ',
       date: [],
       layout: "layout.vto",

--- a/tests/assets/liquid/with-helpers.liquid
+++ b/tests/assets/liquid/with-helpers.liquid
@@ -13,3 +13,7 @@ title: The title
 
 {% include "partial.liquid" %}
 {% include "./_includes/partial.liquid" %}
+
+<strong>{{ "title" | fromPage }}</strong>
+<strong>{{ "title" | fromPageAsync }}</strong>
+<p>{% fromPageTagAsync %}title{% endfromPageTagAsync %}</p>

--- a/tests/assets/nunjucks/with-helpers.njk
+++ b/tests/assets/nunjucks/with-helpers.njk
@@ -13,3 +13,7 @@ title: The title
 
 {% include "partial.njk" %}
 {% include "./_includes/partial.njk" %}
+
+<strong>{{ "title" | fromPage }}</strong>
+<strong>{{ "title" | fromPageAsync }}</strong>
+<p>{% fromPageTagAsync %}title{% endfromPageTagAsync %}</p>

--- a/tests/assets/vento/index.vto
+++ b/tests/assets/vento/index.vto
@@ -14,3 +14,6 @@ layout: layout.vto
 {{ comp button {href, content: "Go to Lume"} /}}
 
 {{ "custom filter" |> upper }}
+
+<strong>{{ "title" |> fromPage }}</strong>
+<strong>{{ "title" |> await fromPageAsync }}</strong>

--- a/tests/liquid.test.ts
+++ b/tests/liquid.test.ts
@@ -43,6 +43,20 @@ Deno.test("build a site with liquid", async (t) => {
     { type: "tag", body: true, async: true },
   );
 
+  site.filter("fromPage", function (key) {
+    return this.data[key];
+  });
+  site.filter("fromPageAsync", function (key) {
+    return Promise.resolve(this.data[key]);
+  }, true);
+  site.helper(
+    "fromPageTagAsync",
+    function (key) {
+      return Promise.resolve(`<strong>${this.data[key]}</strong>`);
+    },
+    { type: "tag", body: true, async: true },
+  );
+
   await build(site);
   await assertSiteSnapshot(t, site);
 });

--- a/tests/liquid.test.ts
+++ b/tests/liquid.test.ts
@@ -44,15 +44,15 @@ Deno.test("build a site with liquid", async (t) => {
   );
 
   site.filter("fromPage", function (key) {
-    return this.data[key];
+    return this?.data[key];
   });
   site.filter("fromPageAsync", function (key) {
-    return Promise.resolve(this.data[key]);
+    return Promise.resolve(this?.data[key]);
   }, true);
   site.helper(
     "fromPageTagAsync",
     function (key) {
-      return Promise.resolve(`<strong>${this.data[key]}</strong>`);
+      return Promise.resolve(`<strong>${this?.data[key]}</strong>`);
     },
     { type: "tag", body: true, async: true },
   );

--- a/tests/nunjucks.test.ts
+++ b/tests/nunjucks.test.ts
@@ -43,6 +43,20 @@ Deno.test("build a site with nunjucks", async (t) => {
     { type: "tag", body: true, async: true },
   );
 
+  site.filter("fromPage", function (key) {
+    return this.data[key];
+  });
+  site.filter("fromPageAsync", function (key) {
+    return Promise.resolve(this.data[key]);
+  }, true);
+  site.helper(
+    "fromPageTagAsync",
+    function (key) {
+      return Promise.resolve(`<strong>${this.data[key]}</strong>`);
+    },
+    { type: "tag", body: true, async: true },
+  );
+
   await build(site);
   await assertSiteSnapshot(t, site);
 });

--- a/tests/nunjucks.test.ts
+++ b/tests/nunjucks.test.ts
@@ -44,15 +44,15 @@ Deno.test("build a site with nunjucks", async (t) => {
   );
 
   site.filter("fromPage", function (key) {
-    return this.data[key];
+    return this?.data[key];
   });
   site.filter("fromPageAsync", function (key) {
-    return Promise.resolve(this.data[key]);
+    return Promise.resolve(this?.data[key]);
   }, true);
   site.helper(
     "fromPageTagAsync",
     function (key) {
-      return Promise.resolve(`<strong>${this.data[key]}</strong>`);
+      return Promise.resolve(`<strong>${this?.data[key]}</strong>`);
     },
     { type: "tag", body: true, async: true },
   );

--- a/tests/vento.test.ts
+++ b/tests/vento.test.ts
@@ -7,6 +7,12 @@ Deno.test("build a site with vento", async (t) => {
   });
 
   site.filter("upper", (value: string) => value.toUpperCase());
+  site.filter("fromPage", function (key) {
+    return this?.data[key];
+  });
+  site.filter("fromPageAsync", function (key) {
+    return Promise.resolve(this?.data[key]);
+  }, true);
 
   await build(site);
   await assertSiteSnapshot(t, site);


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Some templates engines (Vento, nunjucks, liquid) expose the current context in the `this` variable of filters. This allows to get page data without passing explicity throught arguments. This change creates the `HelperThis` type to access to this data. Example:

```js
site.filter("translate", function (key) {
  const lang = this?.data.lang;
  return myTranslateFunction(key, lang);
});
```
The language is not passed explicity to the function. Instead of that, it's got from the `lang` variable of the page. It allows to use the filter in any nunjucks/liquid page:

```html
---
lang: gl
---

<h1>{{ "title" |> translate }}</h1>
```

## Related Issues

This allows to use the `date` filter (or other filters that depends on the page content, like the language) in a more ergonomic way.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
