### PR TITLE
rename the first param of Processor callback type

### DIFF
--- a/core/processors.ts
+++ b/core/processors.ts
@@ -33,10 +33,12 @@ export default class Processors {
   }
 }
 
-/** A (pre)processor */
+/**
+ * Processor callback is used in both (pre)process methods.
+ */
 export type Processor = (
-  pages: Page[],
-  allpages: Page[],
+  filteredPages: Page[],
+  allPages: Page[],
 ) => void | false | Promise<void | false>;
 
 function pageMatches(exts: Extensions, page: Page): boolean {


### PR DESCRIPTION

## Description

This PR is meant to help developers distinguish the 2 params of the Processor callback type.

## Related Issues

fix #538

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
