### PR TITLE
refactor: extract `getOptionsFromCli`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ### Changed
 - `decap_cms` plugin: Add a script in the homepage to redirect to /admin/
   when an invite token or recovery token is detected from netlify identity.
+- `getOptionsFromCli` is moved from `mod.ts` to `utils/cli_options.ts`.
 
 ### Fixed
 - `sitemap` plugin: Add the `xmlns` namespace for localized urls.

--- a/core/utils/cli_options.ts
+++ b/core/utils/cli_options.ts
@@ -1,0 +1,42 @@
+import { parseArgs } from "../../deps/cli.ts";
+import type { DeepPartial } from "./object.ts";
+import type { SiteOptions } from "../site.ts";
+
+export function getOptionsFromCli(): DeepPartial<SiteOptions> {
+  const options = parseArgs(Deno.args, {
+    string: ["src", "dest", "location", "port"],
+    boolean: ["serve", "open"],
+    alias: { dev: "d", serve: "s", port: "p", open: "o" },
+    ["--"]: true,
+  });
+
+  const overrides: DeepPartial<SiteOptions> = {};
+
+  if (options.src) {
+    overrides.src = options.src;
+  }
+
+  if (options.dest) {
+    overrides.dest = options.dest;
+  }
+
+  if (options.location) {
+    overrides.location = new URL(options.location);
+  } else if (options.serve) {
+    overrides.location = new URL(`http://localhost:${options.port || 3000}/`);
+  }
+
+  if (options.port) {
+    (overrides.server ||= {}).port = parseInt(options.port);
+
+    if (overrides.location) {
+      overrides.location.port = options.port;
+    }
+  }
+
+  if (options.open) {
+    (overrides.server ||= {}).open = options.open;
+  }
+
+  return overrides;
+}

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,3 @@
-import { parseArgs } from "./deps/cli.ts";
 import Site from "./core/site.ts";
 import url, { Options as UrlOptions } from "./plugins/url.ts";
 import json, { Options as JsonOptions } from "./plugins/json.ts";
@@ -13,6 +12,7 @@ import { merge } from "./core/utils/object.ts";
 
 import type { DeepPartial } from "./core/utils/object.ts";
 import type { SiteOptions } from "./core/site.ts";
+import { getOptionsFromCli } from "./core/utils/cli_options.ts";
 
 export interface PluginOptions {
   url?: UrlOptions;
@@ -59,43 +59,4 @@ export default function lume(
     .use(search(pluginOptions.search))
     .use(toml(pluginOptions.toml))
     .use(yaml(pluginOptions.yaml));
-}
-
-function getOptionsFromCli(): DeepPartial<SiteOptions> {
-  const options = parseArgs(Deno.args, {
-    string: ["src", "dest", "location", "port"],
-    boolean: ["serve", "open"],
-    alias: { dev: "d", serve: "s", port: "p", open: "o" },
-    ["--"]: true,
-  });
-
-  const overrides: DeepPartial<SiteOptions> = {};
-
-  if (options.src) {
-    overrides.src = options.src;
-  }
-
-  if (options.dest) {
-    overrides.dest = options.dest;
-  }
-
-  if (options.location) {
-    overrides.location = new URL(options.location);
-  } else if (options.serve) {
-    overrides.location = new URL(`http://localhost:${options.port || 3000}/`);
-  }
-
-  if (options.port) {
-    (overrides.server ||= {}).port = parseInt(options.port);
-
-    if (overrides.location) {
-      overrides.location.port = options.port;
-    }
-  }
-
-  if (options.open) {
-    (overrides.server ||= {}).open = options.open;
-  }
-
-  return overrides;
 }


### PR DESCRIPTION
## Description

extracts `getOptionsFromCli` from `mod.ts` to `utils/cli_options.ts` for better reusability.

## Related Issues

- resolves #535

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests. (unneeded)
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
