### PR TITLE
Upgrade date-fns to version 3

### DIFF
--- a/deps/date.ts
+++ b/deps/date.ts
@@ -1,2 +1,2 @@
-export { format } from "npm:date-fns@2.30.0";
-export type { Locale } from "npm:date-fns@2.30.0";
+export { format } from "npm:date-fns@3.0.6/format";
+export type { Locale } from "npm:date-fns@3.0.6/locale";

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -1,8 +1,8 @@
 import { assert, assertStrictEquals as equals } from "../deps/assert.ts";
 import lume from "../mod.ts";
 import date from "../plugins/date.ts";
-import { gl } from "npm:date-fns@3.0.6/locale/gl";
-import { pt } from "npm:date-fns@3.0.6/locale/pt";
+import { gl } from "npm:date-fns/locale/gl";
+import { pt } from "npm:date-fns/locale/pt";
 
 const date0 = new Date(0);
 

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -1,12 +1,8 @@
 import { assert, assertStrictEquals as equals } from "../deps/assert.ts";
 import lume from "../mod.ts";
 import date from "../plugins/date.ts";
-import _gl from "npm:date-fns@2.30.0/locale/gl/index.js";
-import _pt from "npm:date-fns@2.30.0/locale/pt/index.js";
-
-// date-fns provides wrong types under node16 module resolution
-const gl = _gl as Locale;
-const pt = _pt as Locale;
+import { gl } from "npm:date-fns@3.0.6/locale/gl";
+import { pt } from "npm:date-fns@3.0.6/locale/pt";
 
 const date0 = new Date(0);
 


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Version 3 has some breaking changes, but only affect to Lume in how the locales are imported.
It also comes with good types and better support for Deno.

```js
// Version 2
import gl from "npm:date-fns/locale/gl";

// Version 3
import { gl } from "npm:date-fns/locale/gl";
```

More info: https://blog.date-fns.org/v3-is-out/

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
