### PR TITLE
fix: accept multiple options for markdown-it plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 - Pages filtered with `filter_pages` plugin are exported to the sitemap.
 - Ensure `site.options.server.middlewares` array is always defined.
 - Updated dependencies: `lightningcss`, `vento`, `terser`, `autoprefixer`.
+- `site.hooks.addMarkdownItPlugin` accepts multiple options
 
 ## [2.0.3] - 2024-01-12
 ### Added

--- a/plugins/markdown.ts
+++ b/plugins/markdown.ts
@@ -103,8 +103,8 @@ export default function (userOptions?: Options) {
     );
 
     // Hook to add markdown-it plugins
-    site.hooks.addMarkdownItPlugin = (plugin, options) => {
-      engine.use(plugin, options);
+    site.hooks.addMarkdownItPlugin = (plugin, ...options) => {
+      engine.use(plugin, ...options);
     };
 
     // Register custom rules


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Plugins like [markdown-it-container](https://github.com/markdown-it/markdown-it-container?tab=readme-ov-file#api) accepts multiple options. This PR fixes this problem.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
