### PR TITLE
refactor(plugin/favicon): preferred svg icons

### DIFF
--- a/plugins/favicon.ts
+++ b/plugins/favicon.ts
@@ -31,7 +31,7 @@ export const defaults: Options = {
   favicons: [
     {
       url: "/favicon.ico",
-      size: [16, 32],
+      size: [48],
       rel: "icon",
       format: "ico",
     },

--- a/plugins/favicon.ts
+++ b/plugins/favicon.ts
@@ -117,20 +117,20 @@ export default function (userOptions?: Options) {
       for (const page of pages) {
         const document = page.document!;
 
+        for (const favicon of options.favicons) {
+          addIcon(document, {
+            rel: favicon.rel,
+            sizes: favicon.size.map((s) => `${s}x${s}`).join(" "),
+            href: site.url(favicon.url),
+          });
+        }
+
         if (options.input.endsWith(".svg")) {
           addIcon(document, {
             rel: "icon",
             sizes: "any",
             href: site.url(options.input),
             type: "image/svg+xml",
-          });
-        }
-
-        for (const favicon of options.favicons) {
-          addIcon(document, {
-            rel: favicon.rel,
-            sizes: favicon.size.map((s) => `${s}x${s}`).join(" "),
-            href: site.url(favicon.url),
           });
         }
       }

--- a/plugins/favicon.ts
+++ b/plugins/favicon.ts
@@ -120,6 +120,7 @@ export default function (userOptions?: Options) {
         if (options.input.endsWith(".svg")) {
           addIcon(document, {
             rel: "icon",
+            sizes: "any",
             href: site.url(options.input),
             type: "image/svg+xml",
           });


### PR DESCRIPTION
## Description

This PR makes the favicon plugin follow How to Favicon by default.

https://dev.to/masakudamatsu/favicon-nightmare-how-to-maintain-sanity-3al7

## Related Issues

https://github.com/lumeland/lume.land/pull/99

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
