### PR TITLE
docs(readme): remove blockquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # 🔥Lume
 
-> This is the code of the incoming Lume v2. Go to the
-> [v1 branch](https://github.com/lumeland/lume/tree/v1) to see the code of the
-> latest stable version.
-
 [![deno.land/x/lume](https://shield.deno.dev/x/lume)](https://deno.land/x/lume)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 


### PR DESCRIPTION
## Description

Since Lume v2 has been released, I don't think the README needs this blockquote anymore.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
