### PR TITLE
Add an option to configure the PostCSS plugin filter name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project try to adheres to [Semantic Versioning](https://semver.org/).
 Go to the `v1` branch to see the changelog of Lume 1.
 
+## [Unreleased]
+### Added
+- PostCSS plugin: new option `name` with the default value `postcss`.
+
 ## [2.1.2] - 2024-03-14
 ### Added
 - `transform_images` plugin: added the `.webp` extension to the default options.

--- a/plugins/postcss.ts
+++ b/plugins/postcss.ts
@@ -32,12 +32,16 @@ export interface Options {
 
   /** Set `false` to remove the default plugins */
   useDefaultPlugins?: boolean;
+
+  /** The name of the helper */
+  name?: string;
 }
 
 // Default options
 export const defaults: Options = {
   extensions: [".css"],
   useDefaultPlugins: true,
+  name: "postcss",
 };
 
 const defaultPlugins = [
@@ -74,7 +78,7 @@ export default function (userOptions?: Options) {
 
     site.loadAssets(options.extensions);
     site.process(options.extensions, (pages) => concurrent(pages, postCss));
-    site.filter("postcss", filter, true);
+    site.filter(options.name, filter, true);
 
     async function postCss(file: Page) {
       const { content, filename, sourceMap, enableSourceMap } = prepareAsset(

--- a/tests/postcss.test.ts
+++ b/tests/postcss.test.ts
@@ -1,4 +1,5 @@
 import { assertSiteSnapshot, build, getSite } from "./utils.ts";
+import { assert } from "../deps/assert.ts";
 import postcss from "../plugins/postcss.ts";
 import nano from "npm:cssnano";
 
@@ -37,4 +38,30 @@ Deno.test("postcss plugin with hooks", async (t) => {
 
   await build(site);
   await assertSiteSnapshot(t, site);
+});
+
+Deno.test("postcss plugin with default name", () => {
+  const site = getSite({
+    src: "postcss",
+  });
+
+  site.use(postcss());
+
+  const { helpers } = site.renderer;
+
+  assert(helpers.has("postcss"));
+});
+
+Deno.test("postcss plugin with custom name", () => {
+  const site = getSite({
+    src: "postcss",
+  });
+
+  site.use(postcss({
+    name: "css",
+  }));
+
+  const { helpers } = site.renderer;
+
+  assert(helpers.has("css"));
 });


### PR DESCRIPTION
## Description

Add an option to configure the name of the filter added by the PostCSS plugin.

## Related Issues

N/A

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
