### PR TITLE
Fix UnoCSS plugin's JSDoc

### DIFF
--- a/plugins/unocss.ts
+++ b/plugins/unocss.ts
@@ -20,26 +20,34 @@ export interface Options {
   /**
    * Configurations for UnoCSS.
    * @see https://unocss.dev/guide/config-file
+   * @default
+   * {
+   *  presets: [presetUno()]
+   * }
    */
   options?: UserConfig;
 
   /**
    * Set the css filename for all generated styles,
    * Set to `false` to insert a <style> tag per page.
-   * @defaultValue `false`
+   * @default "unocss.css"
    */
-
   cssFile?: false | string;
+  
   /**
    * Process CSS files using UnoCSS transformers.
-   * @defaultValue `[transformerVariantGroup(), transformerDirectives()]`
+   * @default
+   * [
+   *  transformerVariantGroup(),
+   *  transformerDirectives()
+   * ]
    */
   transformers?: SourceCodeTransformer[];
 
   /**
    * Supported CSS reset options.
    * @see https://github.com/unocss/unocss/tree/main/packages/reset
-   * @defaultValue `tailwind`
+   * @default false
    */
   reset?: false | "tailwind" | "tailwind-compat" | "eric-meyer";
 }

--- a/plugins/unocss.ts
+++ b/plugins/unocss.ts
@@ -33,7 +33,7 @@ export interface Options {
    * @default "unocss.css"
    */
   cssFile?: false | string;
-  
+
   /**
    * Process CSS files using UnoCSS transformers.
    * @default


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description
Corrected `@default` values in UnoCSS plugin's JSDoc.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
N/A

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] ~Write tests.~
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] ~Document any change in the `CHANGELOG.md`.~ (too minor to have its own line)
