### PR TITLE
add date format HUMAN_SINCE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ## [2.1.3] - Unreleased
 ### Added
 - PostCSS plugin: new option `name` with the default value `postcss` [#582].
+- date plugin: new formats `HUMAN_SINCE` and `HUMAN_SINCE_STRICT` expose [`formatDistanceToNow`](https://date-fns.org/v3.6.0/docs/formatDistanceToNow) and [`formatDistanceToNowStrict`](https://date-fns.org/v3.6.0/docs/formatDistanceToNowStrict) in the [date-fns](https://date-fns.org/) package, so you can refer to the amount of time that has passed since the an article was last written/modified, rather than just the date it was written.
 
 ### Changed
 - Do not ignore the `/.well-known` folder by default [#585].

--- a/deps/date.ts
+++ b/deps/date.ts
@@ -1,2 +1,4 @@
 export { format } from "npm:date-fns@3.6.0/format";
+export { formatDistanceToNow } from "npm:date-fns@3.6.0/formatDistanceToNow";
+export { formatDistanceToNowStrict } from "npm:date-fns@3.6.0/formatDistanceToNowStrict";
 export type { Locale } from "npm:date-fns@3.6.0/locale";

--- a/plugins/date.ts
+++ b/plugins/date.ts
@@ -1,4 +1,8 @@
-import { format } from "../deps/date.ts";
+import {
+  format,
+  formatDistanceToNow,
+  formatDistanceToNowStrict,
+} from "../deps/date.ts";
 import { merge } from "../core/utils/object.ts";
 
 import type Site from "../core/site.ts";
@@ -56,7 +60,13 @@ export default function (userOptions?: Options) {
       const patt = options.formats[pattern] || pattern;
       const locale = lang ? options.locales[lang] : undefined;
 
-      return format(date, patt, { locale });
+      if (pattern === "HUMAN_SINCE") {
+        return formatDistanceToNow(date, { locale });
+      } else if (pattern === "HUMAN_SINCE_STRICT") {
+        return formatDistanceToNowStrict(date, { locale });
+      } else {
+        return format(date, patt, { locale });
+      }
     }
   };
 }

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -35,6 +35,23 @@ Deno.test("date plugin", () => {
   equals(format(date0, "CUSTOM"), "1970_01");
 });
 
+Deno.test("date plugin formats: HUMAN_SINCE and HUMAN_SINCE_STRICT", () => {
+  const site = lume();
+  site.use(date());
+
+  const { helpers } = site.renderer;
+  assert(helpers.has("date"));
+  const [format] = helpers.get("date")!;
+
+  const aBitMoreThanAYearFromNow = new Date(
+    Date.now() + 367 * 24 * 60 * 60 * 1000,
+  );
+  // See https://date-fns.org/v3.6.0/docs/formatDistanceToNow
+  equals(format(aBitMoreThanAYearFromNow, "HUMAN_SINCE"), "about 1 year");
+  // See https://date-fns.org/v3.6.0/docs/formatDistanceToNowStrict
+  equals(format(aBitMoreThanAYearFromNow, "HUMAN_SINCE_STRICT"), "1 year");
+});
+
 Deno.test("date plugin with custom locale", async () => {
   const site = lume();
   site.use(date({


### PR DESCRIPTION
add date format HUMAN_SINCE
add date format HUMAN_SINCE_STRICT

## Description

I'd like to be able to have lume display an article as having been written "three days ago" rather than "March 23, 2024", but the date package doesn't currently support relative dates. I've exposed functionality in the already-relied-upon [date-fns](https://date-fns.org/) package to add two new date formats: 
 - `"HUMAN_SINCE"`, exposing [`formatDistanceToNow`](https://date-fns.org/v3.6.0/docs/formatDistanceToNow), and
 - `"HUMAN_SINCE_STRICT"`, exposing [`formatDistanceToNowStrict`](https://date-fns.org/v3.6.0/docs/formatDistanceToNowStrict).

Note: I have done everything on the check list below, but that check list does not tell me how I would update the plugin's documentation.

## Related Issues

I proposed a fix without opening an issue.

### Check List

- [X] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [X] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [X] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [X] Write tests.
  - [X] Run deno `fmt` to fix the code format before commit.
  - [X] Document any change in the `CHANGELOG.md`.
