### PR TITLE
chore(unocss): updated deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ## [2.1.4] - Unreleased
 ### Fixed
 - `esbuild` timeout [#591].
+- Updated dependencies: `unocss`.
 
 ## [2.1.3] - 2024-03-28
 ### Added

--- a/deps/unocss.ts
+++ b/deps/unocss.ts
@@ -1,20 +1,12 @@
-// https://github.com/denoland/deno/issues/19096
-import transformerVariantGroupImport from "npm:@unocss/transformer-variant-group@0.58.8";
-import transformerDirectivesImport from "npm:@unocss/transformer-directives@0.58.8";
-
 export {
   createGenerator,
   type SourceCodeTransformer,
   type UnocssPluginContext,
   type UserConfig,
-} from "npm:@unocss/core@0.58.8";
-export { presetUno } from "npm:@unocss/preset-uno@0.58.8";
-export { default as MagicString } from "npm:magic-string@0.30.8";
+} from "npm:@unocss/core@0.59.0";
+export { presetUno } from "npm:@unocss/preset-uno@0.59.0";
+export { default as transformerVariantGroup } from "npm:@unocss/transformer-variant-group@0.59.0";
+export { default as transformerDirectives } from "npm:@unocss/transformer-directives@0.59.0";
+export { default as MagicString } from "npm:magic-string@0.30.9";
 
-// https://github.com/denoland/deno/issues/16458#issuecomment-1295003089
-export const transformerVariantGroup =
-  transformerVariantGroupImport as unknown as typeof transformerDirectivesImport.default;
-export const transformerDirectives =
-  transformerDirectivesImport as unknown as typeof transformerDirectivesImport.default;
-
-export const resetUrl = "https://unpkg.com/@unocss/reset@0.58.8";
+export const resetUrl = "https://unpkg.com/@unocss/reset@0.59.0";


### PR DESCRIPTION
## Description

I fixed the type export in [unocss v0.59.0](https://github.com/unocss/unocss/releases/tag/v0.59.0) so it is no longer necessary to assign types in lume.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
