### PR TITLE
fix(plugin/fff): fix `getGitDate` priority

### DIFF
--- a/plugins/fff.ts
+++ b/plugins/fff.ts
@@ -35,8 +35,12 @@ export default function (userOptions?: Partial<Options>) {
     site.preprocess(options.extensions, (pages) =>
       pages.forEach((page) => {
         if (options.getGitDate && page.src.entry) {
-          page.data.created = getGitDate("created", page.src.entry.src);
-          page.data.updated = getGitDate("modified", page.src.entry.src);
+          if (!page.data.created) {
+            page.data.created = getGitDate("created", page.src.entry.src);
+          }
+          if (!page.data.updated) {
+            page.data.updated = getGitDate("modified", page.src.entry.src);
+          }
         }
 
         page.data = transform(page.data, [


### PR DESCRIPTION
## Description

This PR fixes the FFF plugin's `getGitDate` function to only get the value from git if it is not detected.

## Related Issues

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [ ] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
