### PR TITLE
fix `redirects` plugin for html output

### DIFF
--- a/deps/url.ts
+++ b/deps/url.ts
@@ -1,1 +1,0 @@
-export { join } from "https://deno.land/std@0.224.0/url/join.ts";

--- a/deps/url.ts
+++ b/deps/url.ts
@@ -1,0 +1,1 @@
+export { join } from "https://deno.land/std@0.224.0/url/join.ts";

--- a/plugins/redirects.ts
+++ b/plugins/redirects.ts
@@ -1,6 +1,7 @@
 import { merge } from "../core/utils/object.ts";
 import { Page } from "../core/file.ts";
 import { log } from "../core/utils/log.ts";
+import { join as joinUrl } from "../deps/url.ts";
 
 import type Site from "../core/site.ts";
 
@@ -98,16 +99,17 @@ function parseRedirection(
 function html(redirects: Redirect[], site: Site): void {
   for (const [url, to, statusCode] of redirects) {
     const timeout = (statusCode === 301 || statusCode === 308) ? 0 : 1;
+    const revisedTo = joinUrl(site.options.location, to).pathname;
     const content = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Redirecting…</title>
-  <meta http-equiv="refresh" content="${timeout}; url=${to}">
+  <meta http-equiv="refresh" content="${timeout}; url=${revisedTo}">
 </head>
 <body>
   <h1>Redirecting…</h1>
-  <a href="${to}">Click here if you are not redirected.</a>
+  <a href="${revisedTo}">Click here if you are not redirected.</a>
 </body>
 </html>`;
     const page = Page.create({ url, content });


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

`redirects` plugin not working when `--location` is specified at the build time, if the location is not a root url.

For example, my blog url is `https://thautwarm.github.io/Site-33/` instead of `https://thautwarm.github.io/`, then the redirection fails to resolve urls.

## Related Issues

No issue yet. I found the case by
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
