### PR TITLE
fix: stale live reload due to dropped watch events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 - Watcher new files on Windows.
 - Feed plugin: error when the updated/published value is a string [#638].
 - Fixed esbuild reload [#647].
+- Fixed serve showing stale pages [#649].
 
 ## [2.2.4] - 2024-07-18
 ### Added

--- a/core/watcher.ts
+++ b/core/watcher.ts
@@ -77,30 +77,31 @@ export default class FSWatcher implements Watcher {
   async start() {
     const { root, ignore, debounce } = this.options;
     const watcher = Deno.watchFs(root);
-    const changes = new Set<string>();
+    const changeQueue: Set<string>[] = [];
     let timer = 0;
     let runningCallback = false;
 
     await this.dispatchEvent({ type: "start" });
 
     const callback = async () => {
-      if (!changes.size || runningCallback) {
-        return;
-      }
-
-      const files = new Set(changes);
-      changes.clear();
-
       runningCallback = true;
 
-      try {
-        const result = await this.dispatchEvent({ type: "change", files });
-        if (false === result) {
-          return watcher.close();
+      let changes: Set<string> | undefined;
+      while ((changes = changeQueue.pop()) !== undefined) {
+        try {
+          const result = await this.dispatchEvent({
+            type: "change",
+            files: changes,
+          });
+          if (false === result) {
+            runningCallback = false;
+            return watcher.close();
+          }
+        } catch (error) {
+          await this.dispatchEvent({ type: "error", error });
         }
-      } catch (error) {
-        await this.dispatchEvent({ type: "error", error });
       }
+
       runningCallback = false;
     };
 
@@ -123,11 +124,27 @@ export default class FSWatcher implements Watcher {
         continue;
       }
 
+      const changes = new Set<string>();
       paths.forEach((path) => changes.add(normalizePath(relative(root, path))));
 
-      // Debounce
-      clearTimeout(timer);
-      timer = setTimeout(callback, debounce ?? 100);
+      // If we're already processing and have a pending
+      // queue item, we can potentially batch the two
+      // together.
+      if (runningCallback && changeQueue.length > 0) {
+        const last = changeQueue[changeQueue.length - 1];
+        const newChanges = Array.from(changes.values());
+        if (newChanges.every((change) => last.has(change))) {
+          continue;
+        }
+      }
+      changeQueue.unshift(changes);
+
+      // Only start if processing queue is not already running
+      if (!runningCallback) {
+        // Debounce
+        clearTimeout(timer);
+        timer = setTimeout(callback, debounce ?? 100);
+      }
     }
   }
 }

--- a/core/watcher.ts
+++ b/core/watcher.ts
@@ -128,22 +128,19 @@ export default class FSWatcher implements Watcher {
       paths.forEach((path) => changes.add(normalizePath(relative(root, path))));
 
       // If we're already processing and have a pending
-      // queue item, we can potentially batch the two
-      // together.
+      // queue item, we can merge all future changes together
       if (runningCallback && changeQueue.length > 0) {
         const last = changeQueue[changeQueue.length - 1];
-        const newChanges = Array.from(changes.values());
-        if (newChanges.every((change) => last.has(change))) {
-          continue;
-        }
-      }
-      changeQueue.unshift(changes);
+        changeQueue[changeQueue.length - 1] = last.union(changes);
+      } else {
+        changeQueue.unshift(changes);
 
-      // Only start if processing queue is not already running
-      if (!runningCallback) {
-        // Debounce
-        clearTimeout(timer);
-        timer = setTimeout(callback, debounce ?? 100);
+        // Only start if processing queue is not already running
+        if (!runningCallback) {
+          // Debounce
+          clearTimeout(timer);
+          timer = setTimeout(callback, debounce ?? 100);
+        }
       }
     }
   }


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
While working on docs.deno.com we noticed that the page shown in the browser would often go out of sync with the actual content on disk. Debugging this further lead two a discovery of two separate bugs in the watcher + live reloading code.

When you edit a file and hit save while a previous change is still being processed it would be dropped here:

https://github.com/lumeland/lume/blob/abefe9fac36df830446acf679adadc64787d9893/core/watcher.ts#L87-L89

This lead to generated files lagging behind one or potentially more changes depending on how many watch events were dropped. I've resolved this by adding a queue of events that is processed in order. To avoid processing the same file more often than necessary there is a small optimisation that merges queued events if they are the same.

But with this fix in place the browser was still showing a previous version of the page. Turns out that we frequently run into the situation where a watch event is received, whilst the browser is disconnected and is in the process of being reloaded due to an earlier change. These events were dropped here:

https://github.com/lumeland/lume/blob/abefe9fac36df830446acf679adadc64787d9893/middlewares/reload.ts#L16-L19

To resolve this, I've added a simple "revision" tracking mechanism. When a new connection is opened the server immediately sends the current revision to the browser so that it can check if it has become stale and potentially reload the page. The initial revision is included in the HTML and passed to the `liveReload()` function as an argument.

## Before

Notice how even refreshing the browser shows the stale version.

https://github.com/user-attachments/assets/2699c590-8731-4576-a687-9fb11f00f269

## After

Notice how the changes are all sent to the browser and it has the correct state even if you reload it. It seems like during processing the lume server is blocked from responding to the browser, otherwise the intermediate states would also be shown in it.

https://github.com/user-attachments/assets/09e16d73-f674-4464-a536-69cd7985e72c

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
