### PR TITLE
perf: don't re-create regex on every log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 - Watcher new files on Windows.
 - Feed plugin: error when the updated/published value is a string [#638].
 - Fixed esbuild reload [#647].
+- Speed up logging to console with colors [#651]
 
 ## [2.2.4] - 2024-07-18
 ### Added

--- a/core/utils/log.ts
+++ b/core/utils/log.ts
@@ -21,6 +21,8 @@ if (!level || level === "NOTSET") {
   level = "INFO";
 }
 
+const COLOR_TAG_REG = /<(\w+)>([^<]+)<\/\1>/g;
+
 /**
  * This is the default logger. It will output color coded log messages to the
  * console via `console.log()`.
@@ -42,7 +44,7 @@ class ConsoleHandler extends logger.BaseHandler {
     }
 
     return msg.replaceAll(
-      /<(\w+)>([^<]+)<\/\1>/g,
+      COLOR_TAG_REG,
       (_, name, content) => logFormats[name]!(content),
     );
   }


### PR DESCRIPTION
## Description

Noticed in traces that logging alone takes quite a bit time when building deno.docs.com . Whilst it's not much an easy fix is to hoist out the regex which saves about 979ms.

Before:

<img width="456" alt="Screenshot 2024-08-14 at 09 22 46" src="https://github.com/user-attachments/assets/c56ec280-fd16-4461-b683-9cc9cd383768">

After:

<img width="425" alt="Screenshot 2024-08-14 at 09 22 36" src="https://github.com/user-attachments/assets/43c068bc-d20e-4772-9d16-63fc4f741963">


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [ ] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
