### PR TITLE
Fix nav default order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 - Fixed esbuild reload [#647].
 - Fixed serve showing stale pages [#649].
 - Speed up logging to console with colors [#651]
+- Nav plugin: did ignore default order option.
 
 ## [2.2.4] - 2024-07-18
 ### Added

--- a/plugins/nav.ts
+++ b/plugins/nav.ts
@@ -26,7 +26,7 @@ export function nav(userOptions?: Options) {
   const options = merge(defaults, userOptions);
 
   return (site: Site) => {
-    const nav = new Nav(site.search);
+    const nav = new Nav(site.search, options.order);
     site.data(options.name, nav);
     site.addEventListener("beforeUpdate", () => nav.deleteCache());
   };
@@ -36,9 +36,11 @@ export function nav(userOptions?: Options) {
 export class Nav {
   #cache = new Map<string, NavData>();
   #search: Searcher;
+  #defaultOrder?: string;
 
-  constructor(searcher: Searcher) {
+  constructor(searcher: Searcher, defaultOrder?: string) {
     this.#search = searcher;
+    this.#defaultOrder = defaultOrder;
   }
 
   /** Clear the cache (used after a change in watch mode) */
@@ -171,7 +173,7 @@ export class Nav {
       }
     }
 
-    return convert(nav, buildSort(sort || "basename"));
+    return convert(nav, buildSort(sort || this.#defaultOrder || "basename"));
   }
 }
 

--- a/tests/__snapshots__/nav.test.ts.snap
+++ b/tests/__snapshots__/nav.test.ts.snap
@@ -215,7 +215,8 @@ snapshot[`nav plugin 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "docs",
       children: "",
@@ -337,7 +338,8 @@ snapshot[`nav plugin 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "about-docs",
       children: "",
@@ -463,7 +465,8 @@ snapshot[`nav plugin 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "pages",
       children: "",
@@ -590,7 +593,8 @@ snapshot[`nav plugin 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "first",
       children: "",
@@ -715,7 +719,8 @@ snapshot[`nav plugin 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "second",
       children: "",
@@ -835,7 +840,8 @@ snapshot[`nav plugin 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "index",
       children: "",
@@ -1082,7 +1088,8 @@ snapshot[`nav plugin with pretty urls disabled 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "docs",
       children: "",
@@ -1204,7 +1211,8 @@ snapshot[`nav plugin with pretty urls disabled 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "about-docs",
       children: "",
@@ -1330,7 +1338,8 @@ snapshot[`nav plugin with pretty urls disabled 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "pages",
       children: "",
@@ -1457,7 +1466,8 @@ snapshot[`nav plugin with pretty urls disabled 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "first",
       children: "",
@@ -1582,7 +1592,8 @@ snapshot[`nav plugin with pretty urls disabled 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "second",
       children: "",
@@ -1698,7 +1709,8 @@ snapshot[`nav plugin with pretty urls disabled 3`] = `
       
     </nav>
   </body>
-</html>',
+</html>
+',
     data: {
       basename: "index",
       children: "",

--- a/tests/assets/nav/_includes/main.vto
+++ b/tests/assets/nav/_includes/main.vto
@@ -16,7 +16,7 @@
 
     <nav>
       <ul>
-      {{- for item of nav.menu("/", "", "order basename").children }}
+      {{- for item of nav.menu("/", "").children }}
         <li>
           {{ include "./step.vto" { item } }}
         </li>

--- a/tests/nav.test.ts
+++ b/tests/nav.test.ts
@@ -6,7 +6,7 @@ Deno.test("nav plugin", async (t) => {
     src: "nav",
   });
 
-  site.use(nav());
+  site.use(nav({ order: "order basename" }));
 
   await build(site);
   await assertSiteSnapshot(t, site);
@@ -18,7 +18,7 @@ Deno.test("nav plugin with pretty urls disabled", async (t) => {
     prettyUrls: false,
   });
 
-  site.use(nav());
+  site.use(nav({ order: "order basename" }));
 
   await build(site);
   await assertSiteSnapshot(t, site);


### PR DESCRIPTION
## Description

Nav plugin was ignoring the default `order` for the children option passed during its import/installation.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
