### PR TITLE
fallback to git last modified upon empty git created date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ### Added
 - Basic auth middleware: Added `errorMessage` option.
 ### Fixed
+- When using special value `git created` for `date` variable, it will fall back to `git modified` first, then filesystem last modified date.
 - Updated dependencies: `linkedom`, `sass`, `satori`, `terser`, `liquidjs`, `tailwind`, `date-fns`, `std`, `esbuild`, `preact`, `lightningcss`, `postcss`, `remark-rehype`, `react` types, `unocss`.
 
 ## [2.3.2] - 2024-09-10

--- a/core/utils/page_date.ts
+++ b/core/utils/page_date.ts
@@ -24,7 +24,12 @@ export function getPageDate(page: Page): Date {
         case "git last modified":
           return getGitDate("modified", entry.src) || info.mtime || new Date();
         case "git created":
-          return getGitDate("created", entry.src) || info.birthtime ||
+          // getGitDate("created", ...) uses `git log --diff-filter=A`
+          // which returns nothing for files where the latest commit had a merge conflict.
+          // Therefore we fallback to last modified time from git history,
+          // which is more reliable than file system creation time under most CI environments.
+          return getGitDate("created", entry.src) ||
+            getGitDate("modified", entry.src) || info.birthtime ||
             new Date();
       }
     }


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

`getGitDate("created", ...)` uses `git log --diff-filter=A`
which returns nothing for files where the latest commit had a merge conflict.
Previously lume would use filesystem last modified date as a fallback.
This commit introduces a change to fall back to `git modified` first when using special value `git created` and `getGitDate("created", ...)` returns nothing.
I think `git modified` is more reliable than file system creation time under most CI environments.


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests. (This is for an uncommon corner case so I skipped tests for now.)
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
