### PR TITLE
Improve code_highlight configuration options type to be Partial

### DIFF
--- a/plugins/code_highlight.ts
+++ b/plugins/code_highlight.ts
@@ -83,7 +83,7 @@ export function codeHighlight(userOptions?: Options) {
     function processCodeHighlight(pages: Page[]) {
       for (const page of pages) {
         page.document!.querySelectorAll<HTMLElement>(
-          options.options.cssSelector,
+          options.options.cssSelector!,
         )
           .forEach((element) => {
             try {

--- a/plugins/code_highlight.ts
+++ b/plugins/code_highlight.ts
@@ -20,7 +20,7 @@ export interface Options {
    * Options passed to highlight.js.
    * @see https://highlightjs.readthedocs.io/en/latest/api.html#configure
    */
-  options?: Omit<HLJSOptions, "__emitter">;
+  options?: Partial<Omit<HLJSOptions, "__emitter">>;
 
   /**
    * The theme or themes to download


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description
Make it so users of the Highlight Code Plugin don't have to pass all options to the configure wrapper for highlightjs.
The object is only merged with the `defaults` and then passed to [PublicApi::configure](https://highlightjs.readthedocs.io/en/latest/api.html#configure) which has a type signature itself of:
`configure: (options: Partial<HLJSOptions>) => void`
https://github.com/highlightjs/highlight.js/blob/4e485f222e8c604b92937870414cf401e9dff31f/types/index.d.ts#L38

## Related Issues
Example: I wanted to have the `pre code.mermaid-language` processed by another plugin so i wanted to add:
```
site.use(codeHighlight({
    options: {
        noHighlightRe: /^mermaid$/i
    }
}));
```
Deno-ts then sais:

> Type '{ noHighlightRe: RegExp; }' is missing the following properties from type 'Omit<HLJSOptions, "__emitter">': languageDetectRe, classPrefix, cssSelector`

### Check List
I assume it's not a big enough change to warrant tests or an entry in _CHANGELOG.md_.
- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
