### PR TITLE
Add plugin 'purgecss'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project try to adheres to [Semantic Versioning](https://semver.org/).
 Go to the `v1` branch to see the changelog of Lume 1.
 
+## [2.4.2] - Unreleased
+### Fixed
+- Restore `minify_html` dependency creating a copy on deno.land/x [#689].
+- Updated icon catalogs to the latest version.
+- Removed license comment of lucide icon collection.
+
 ## [2.4.1] - 2024-11-07
 ### Fixed
 - Several bugs in the `icons` plugin:
@@ -596,7 +602,9 @@ Go to the `v1` branch to see the changelog of Lume 1.
 [#683]: https://github.com/lumeland/lume/issues/683
 [#685]: https://github.com/lumeland/lume/issues/685
 [#686]: https://github.com/lumeland/lume/issues/686
+[#689]: https://github.com/lumeland/lume/issues/689
 
+[2.4.2]: https://github.com/lumeland/lume/compare/v2.4.1...HEAD
 [2.4.1]: https://github.com/lumeland/lume/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/lumeland/lume/compare/v2.3.3...v2.4.0
 [2.3.3]: https://github.com/lumeland/lume/compare/v2.3.2...v2.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project try to adheres to [Semantic Versioning](https://semver.org/).
 Go to the `v1` branch to see the changelog of Lume 1.
 
 ## [2.4.3] - Unreleased
+### Added
+- New plugin: `purgecss` to remove unused CSS. [#693]
+
 ### Fixed
 - Ensure `LUME_LIVE_RELOAD` env variable is available in the _config file.
 - `on_demand` middleware types.
@@ -610,6 +613,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 [#685]: https://github.com/lumeland/lume/issues/685
 [#686]: https://github.com/lumeland/lume/issues/686
 [#689]: https://github.com/lumeland/lume/issues/689
+[#693]: https://github.com/lumeland/lume/issues/693
 
 [2.4.3]: https://github.com/lumeland/lume/compare/v2.4.2...HEAD
 [2.4.2]: https://github.com/lumeland/lume/compare/v2.4.1...v2.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ### Fixed
 - Ensure `LUME_LIVE_RELOAD` env variable is available in the _config file.
 - `on_demand` middleware types.
+- `on_demand` plugin doesn't filter scoped pages.
 - Updates dependencies: `std`, `sass`, `postcss`, `decap-cms` and some icons.
 
 ## [2.4.2] - 2024-11-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ## [2.4.3] - Unreleased
 ### Fixed
 - Ensure `LUME_LIVE_RELOAD` env variable is available in the _config file.
+- Updates dependencies: `std`, `sass`, `postcss`, `decap-cms` and some icons.
 
 ## [2.4.2] - 2024-11-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project try to adheres to [Semantic Versioning](https://semver.org/).
 Go to the `v1` branch to see the changelog of Lume 1.
 
+## [2.4.3] - Unreleased
+### Fixed
+- Ensure `LUME_LIVE_RELOAD` env variable is available in the _config file.
+
 ## [2.4.2] - 2024-11-10
 ### Fixed
 - Restore `minify_html` dependency creating a copy on deno.land/x [#689].
@@ -604,6 +608,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 [#686]: https://github.com/lumeland/lume/issues/686
 [#689]: https://github.com/lumeland/lume/issues/689
 
+[2.4.3]: https://github.com/lumeland/lume/compare/v2.4.2...HEAD
 [2.4.2]: https://github.com/lumeland/lume/compare/v2.4.1...v2.4.2
 [2.4.1]: https://github.com/lumeland/lume/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/lumeland/lume/compare/v2.3.3...v2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project try to adheres to [Semantic Versioning](https://semver.org/).
 Go to the `v1` branch to see the changelog of Lume 1.
 
-## [2.4.2] - Unreleased
+## [2.4.2] - 2024-11-10
 ### Fixed
 - Restore `minify_html` dependency creating a copy on deno.land/x [#689].
 - Updated icon catalogs to the latest version.
@@ -604,7 +604,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 [#686]: https://github.com/lumeland/lume/issues/686
 [#689]: https://github.com/lumeland/lume/issues/689
 
-[2.4.2]: https://github.com/lumeland/lume/compare/v2.4.1...HEAD
+[2.4.2]: https://github.com/lumeland/lume/compare/v2.4.1...v2.4.2
 [2.4.1]: https://github.com/lumeland/lume/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/lumeland/lume/compare/v2.3.3...v2.4.0
 [2.3.3]: https://github.com/lumeland/lume/compare/v2.3.2...v2.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ## [2.4.3] - Unreleased
 ### Fixed
 - Ensure `LUME_LIVE_RELOAD` env variable is available in the _config file.
+- `on_demand` middleware types.
 - Updates dependencies: `std`, `sass`, `postcss`, `decap-cms` and some icons.
 
 ## [2.4.2] - 2024-11-10

--- a/cli/build_worker.ts
+++ b/cli/build_worker.ts
@@ -32,10 +32,10 @@ interface BuildOptions {
 }
 
 async function build({ type, config, serve }: BuildOptions) {
-  const site = await buildSite(config);
-
   // Set the live reload environment variable to add hash to the URLs in the module loader
   setEnv("LUME_LIVE_RELOAD", "true");
+
+  const site = await buildSite(config);
 
   // Start the watcher
   const watcher = site.getWatcher();

--- a/core/site.ts
+++ b/core/site.ts
@@ -715,8 +715,9 @@ export default class Site {
 
     // Get the site content
     const [pages] = await this.source.build(
-      (entry) =>
-        (entry.type === "directory" && file.startsWith(entry.path)) ||
+      (entry, page) =>
+        (entry.type === "directory" && file.startsWith(entry.path) && (!page ||
+          page.sourcePath === file)) ||
         entry.path === file,
     );
 

--- a/core/source.ts
+++ b/core/source.ts
@@ -247,6 +247,10 @@ export default class Source {
         page.data.url = url;
         page.data.date = getPageDate(page);
         page.data.page = page;
+
+        if (buildFilters.some((filter) => !filter(dir, page))) {
+          continue;
+        }
         pages.push(page);
       }
     }

--- a/core/utils/lume_config.ts
+++ b/core/utils/lume_config.ts
@@ -36,6 +36,7 @@ export const pluginNames = [
   "postcss",
   "prism",
   "pug",
+  "purgecss",
   "reading_info",
   "redirects",
   "relations",

--- a/deps/assert.ts
+++ b/deps/assert.ts
@@ -1,1 +1,1 @@
-export * from "jsr:@std/assert@1.0.7";
+export * from "jsr:@std/assert@1.0.8";

--- a/deps/decap.ts
+++ b/deps/decap.ts
@@ -1,3 +1,3 @@
 export const decapUrl =
-  "https://cdn.jsdelivr.net/npm/decap-cms@3.3.3/dist/decap-cms.js";
+  "https://cdn.jsdelivr.net/npm/decap-cms@3.4.0/dist/decap-cms.js";
 export const serverUrl = "npm:decap-server@3.1.2";

--- a/deps/http.ts
+++ b/deps/http.ts
@@ -1,1 +1,1 @@
-export { serveFile } from "jsr:@std/http@1.0.9/file-server";
+export { serveFile } from "jsr:@std/http@1.0.10/file-server";

--- a/deps/icons.ts
+++ b/deps/icons.ts
@@ -33,7 +33,7 @@ export const catalogs: Catalog[] = [
   {
     // https://lucide.dev/
     id: "lucide",
-    src: "https://cdn.jsdelivr.net/npm/lucide-static@0.454.0/icons/{name}.svg",
+    src: "https://cdn.jsdelivr.net/npm/lucide-static@0.456.0/icons/{name}.svg",
   },
   {
     // https://fonts.google.com/icons?icon.set=Material+Symbols
@@ -175,7 +175,7 @@ export const catalogs: Catalog[] = [
     // https://react.fluentui.dev/?path=/docs/icons-catalog--docs
     id: "fluent",
     src:
-      "https://cdn.jsdelivr.net/npm/@fluentui/svg-icons@1.1.264/icons/{name}_{variant}.svg",
+      "https://cdn.jsdelivr.net/npm/@fluentui/svg-icons@1.1.265/icons/{name}_{variant}.svg",
     variants: [
       { id: "outlined", path: "regular" },
       "filled",

--- a/deps/icons.ts
+++ b/deps/icons.ts
@@ -122,7 +122,7 @@ export const catalogs: Catalog[] = [
     // https://tabler.io/icons
     id: "tabler",
     src:
-      "https://cdn.jsdelivr.net/npm/@tabler/icons@3.21.0/icons/{variant}/{name}.svg",
+      "https://cdn.jsdelivr.net/npm/@tabler/icons@3.22.0/icons/{variant}/{name}.svg",
     variants: ["filled", "outline"],
   },
   {
@@ -139,7 +139,7 @@ export const catalogs: Catalog[] = [
     // https://iconoir.com/
     id: "iconoir",
     src:
-      "https://cdn.jsdelivr.net/npm/iconoir@7.9.0/icons/{variant}/{name}.svg",
+      "https://cdn.jsdelivr.net/npm/iconoir@7.10.0/icons/{variant}/{name}.svg",
     variants: ["regular", "solid"],
   },
   {

--- a/deps/log.ts
+++ b/deps/log.ts
@@ -1,1 +1,1 @@
-export * from "jsr:@std/log@0.224.9";
+export * from "jsr:@std/log@0.224.10";

--- a/deps/media_types.ts
+++ b/deps/media_types.ts
@@ -1,1 +1,1 @@
-export * from "jsr:@std/media-types@1.0.3";
+export * from "jsr:@std/media-types@1.1.0";

--- a/deps/minify_html.ts
+++ b/deps/minify_html.ts
@@ -1,11 +1,11 @@
-// https://github.com/wilsonzlin/minify-html
-export { minify } from "https://wilsonl.in/minify-html/deno/0.15.0/index.js";
-import initWasm from "https://wilsonl.in/minify-html/deno/0.15.0/index.js";
+export { minify } from "https://deno.land/x/minify_html@0.15.0/mod.js";
+import initWasm from "https://deno.land/x/minify_html@0.15.0/mod.js";
 import { read } from "../core/utils/read.ts";
 
 // Initialize the WASM module
-const url = "https://wilsonl.in/minify-html/deno/0.15.0/index_bg.wasm";
+const url = "https://deno.land/x/minify_html@0.15.0/index_bg.wasm";
 const wasm = await read(url, true);
+
 await initWasm(wasm);
 
 export interface Options {

--- a/deps/postcss.ts
+++ b/deps/postcss.ts
@@ -1,3 +1,3 @@
-export { default as postcss } from "npm:postcss@8.4.47";
+export { default as postcss } from "npm:postcss@8.4.49";
 export { default as postcssImport } from "npm:postcss-import@16.1.0";
 export { default as autoprefixer } from "npm:autoprefixer@10.4.20";

--- a/deps/purgecss.ts
+++ b/deps/purgecss.ts
@@ -1,0 +1,2 @@
+export * from "npm:purgecss@6.0.0";
+export { default as purgeHtml } from "npm:purgecss-from-html@6.0.0/lib/purgecss-from-html.esm.js";

--- a/deps/sass.ts
+++ b/deps/sass.ts
@@ -1,1 +1,1 @@
-export * from "npm:sass@1.80.6";
+export * from "npm:sass@1.80.7";

--- a/deps/snapshot.ts
+++ b/deps/snapshot.ts
@@ -1,1 +1,1 @@
-export * from "jsr:@std/testing@1.0.4/snapshot";
+export * from "jsr:@std/testing@1.0.5/snapshot";

--- a/middlewares/on_demand.ts
+++ b/middlewares/on_demand.ts
@@ -94,7 +94,9 @@ export function getRouter(routes: Map<string, string>): Router {
 }
 
 export interface MiddlewareOptions {
-  extraData?: (request: Request) => Record<string, unknown>;
+  extraData?: (
+    request: Request,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
   routesFile?: string;
 }
 

--- a/plugins/icons.ts
+++ b/plugins/icons.ts
@@ -17,6 +17,8 @@ export const defaults: Options = {
   catalogs,
 };
 
+const commentRegexp = /<!--[\s\S]*?-->/;
+
 export function icons(userOptions?: Options) {
   const options = merge(defaults, userOptions);
 
@@ -42,7 +44,7 @@ export function icons(userOptions?: Options) {
       for (const [file, url] of icons) {
         const content = await readFile(url);
         const page = await site.getOrCreatePage(file);
-        page.content = content;
+        page.content = content.replace(commentRegexp, ""); // Remove comment
       }
     });
   };

--- a/plugins/purgecss.ts
+++ b/plugins/purgecss.ts
@@ -1,0 +1,84 @@
+import { PurgeCSS, purgeHtml } from "../deps/purgecss.ts";
+import { merge } from "../core/utils/object.ts";
+import { concurrent } from "../core/utils/concurrent.ts";
+import { getExtension, matchExtension } from "../core/utils/path.ts";
+
+import type Site from "../core/site.ts";
+import type { Page } from "../core/file.ts";
+import type { RawContent, UserDefinedOptions } from "../deps/purgecss.ts";
+
+export interface Options {
+  /** The list of extensions this plugin applies to. */
+  extensions?: string[];
+
+  /** The list of page extensions loaded as content. */
+  contentExtensions?: string[];
+
+  /** Options for purgecss */
+  options?: Partial<UserDefinedOptions>;
+}
+
+// Default options
+export const defaults: Options = {
+  extensions: [".css"],
+  contentExtensions: [".html", ".js"],
+  options: {
+    extractors: [],
+  },
+};
+
+/**
+ * A plugin to remove unused CSS
+ */
+export function purgecss(userOptions?: Options) {
+  const options = merge(defaults, userOptions);
+
+  options.options.extractors!.push({
+    extractor: purgeHtml,
+    extensions: ["html"],
+  });
+
+  return (site: Site) => {
+    site.process(options.extensions, async (pages, allPages) => {
+      const content: RawContent[] = [];
+      for (const page of allPages) {
+        if (!matchExtension(options.contentExtensions, page.outputPath)) {
+          continue;
+        }
+
+        const pageContent = page.content;
+        if (typeof pageContent !== "string") {
+          return;
+        }
+
+        content.push({
+          raw: pageContent,
+          extension: getExtension(page.outputPath).slice(1),
+        });
+      }
+
+      await concurrent(pages, async (page: Page) => {
+        const pageContent = page.content;
+        if (typeof pageContent !== "string") {
+          return;
+        }
+
+        const purgeOptions: UserDefinedOptions = {
+          ...options.options,
+          content: (options.options.content || []).concat(content),
+          css: [
+            {
+              raw: pageContent,
+            },
+          ],
+        };
+
+        const result = await new PurgeCSS().purge(purgeOptions);
+
+        page.content = result[0].css;
+      });
+    });
+  };
+}
+
+export default purgecss;

--- a/tests/__snapshots__/decap_cms.test.ts.snap
+++ b/tests/__snapshots__/decap_cms.test.ts.snap
@@ -158,7 +158,7 @@ local_backend: false
           <title>Admin</title>
         </head>
         <body>
-        <link href="/admin/config.yml" type="text/yaml" rel="cms-config-url"><script src="https://cdn.jsdelivr.net/npm/decap-cms@3.3.3/dist/decap-cms.js"></script><script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+        <link href="/admin/config.yml" type="text/yaml" rel="cms-config-url"><script src="https://cdn.jsdelivr.net/npm/decap-cms@3.4.0/dist/decap-cms.js"></script><script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
         </body>
         </html>
         ',
@@ -173,7 +173,7 @@ local_backend: false
           <title>Admin</title>
         </head>
         <body>
-        <link href="/admin/config.yml" type="text/yaml" rel="cms-config-url"><script src="https://cdn.jsdelivr.net/npm/decap-cms@3.3.3/dist/decap-cms.js"></script><script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+        <link href="/admin/config.yml" type="text/yaml" rel="cms-config-url"><script src="https://cdn.jsdelivr.net/npm/decap-cms@3.4.0/dist/decap-cms.js"></script><script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
         </body>
         </html>
         ',

--- a/tests/__snapshots__/icons.test.ts.snap
+++ b/tests/__snapshots__/icons.test.ts.snap
@@ -231,7 +231,7 @@ snapshot[`icons plugin 3`] = `
     },
   },
   {
-    content: '<!-- @license lucide-static v0.454.0 - ISC -->
+    content: '
 <svg
   class="lucide lucide-alarm-clock"
   xmlns="http://www.w3.org/2000/svg"

--- a/tests/__snapshots__/purgecss.test.ts.snap
+++ b/tests/__snapshots__/purgecss.test.ts.snap
@@ -1,0 +1,854 @@
+export const snapshot = {};
+
+snapshot[`purgecss plugin 1`] = `
+{
+  formats: [
+    {
+      engines: 0,
+      ext: ".page.toml",
+      loader: [AsyncFunction: toml],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".page.ts",
+      loader: [AsyncFunction: module],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".page.js",
+      loader: [AsyncFunction: module],
+      pageType: "page",
+    },
+    {
+      engines: 0,
+      ext: ".page.jsonc",
+      loader: [AsyncFunction: json],
+      pageType: "page",
+    },
+    {
+      engines: 0,
+      ext: ".page.json",
+      loader: [AsyncFunction: json],
+      pageType: "page",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: 0,
+      ext: ".json",
+      loader: [AsyncFunction: json],
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: 0,
+      ext: ".jsonc",
+      loader: [AsyncFunction: json],
+    },
+    {
+      engines: 1,
+      ext: ".md",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      assetLoader: [AsyncFunction: text],
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".js",
+      loader: [AsyncFunction: module],
+      pageType: "asset",
+    },
+    {
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".ts",
+      loader: [AsyncFunction: module],
+    },
+    {
+      engines: 1,
+      ext: ".vento",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".vto",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      dataLoader: [AsyncFunction: toml],
+      engines: 0,
+      ext: ".toml",
+      loader: [AsyncFunction: toml],
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: 0,
+      ext: ".yaml",
+      loader: [AsyncFunction: yaml],
+      pageType: "page",
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: 0,
+      ext: ".yml",
+      loader: [AsyncFunction: yaml],
+      pageType: "page",
+    },
+    {
+      assetLoader: [AsyncFunction: text],
+      engines: undefined,
+      ext: ".css",
+      pageType: "asset",
+    },
+  ],
+  src: [
+    "/",
+    "/_includes",
+    "/_includes/footer.vto",
+    "/_includes/layout.vto",
+    "/index.vto",
+    "/pages",
+    "/pages/page1.md",
+    "/pages/page2.page.js",
+    "/script.js",
+    "/static",
+    "/static/static.html",
+    "/styles.css",
+  ],
+}
+`;
+
+snapshot[`purgecss plugin 2`] = `
+[
+  {
+    entry: "/static/static.html",
+    flags: [],
+    outputPath: "/static.html",
+  },
+]
+`;
+
+snapshot[`purgecss plugin 3`] = `
+[
+  {
+    content: '<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TÍTULO</title>
+</head>
+<body>
+  <h1>Título</h1>
+
+<strong>strong</strong>
+
+<div class="content-vento" tabindex="0">Content</div>
+
+
+  <footer>
+Título
+</footer>
+</body>
+</html>
+',
+    data: {
+      basename: "index",
+      children: '<h1>Título</h1>
+
+<strong>strong</strong>
+
+<div class="content-vento" tabindex="0">Content</div>
+',
+      content: '<h1>{{ title }}</h1>
+
+<strong>strong</strong>
+
+<div class="content-vento" tabindex="0">Content</div>
+',
+      date: [],
+      layout: "layout.vto",
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      title: "Título",
+      url: "/",
+    },
+    src: {
+      asset: false,
+      ext: ".vto",
+      path: "/index",
+      remote: undefined,
+    },
+  },
+  {
+    content: "<!DOCTYPE html>
+<p>Content of Page 1</p>
+",
+    data: {
+      basename: "page1",
+      children: "<p>Content of Page 1</p>
+",
+      content: "Content of Page 1
+",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      title: "Page 1",
+      url: "/pages/page1/",
+    },
+    src: {
+      asset: false,
+      ext: ".md",
+      path: "/pages/page1",
+      remote: undefined,
+    },
+  },
+  {
+    content: '<!DOCTYPE html>
+<div class="content-dynamic">Content of Page 2</div>',
+    data: {
+      basename: "page2",
+      children: '<div class="content-dynamic">Content of Page 2</div>',
+      content: '<div class="content-dynamic">Content of Page 2</div>',
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      title: "Page 2",
+      url: "/page_2/",
+    },
+    src: {
+      asset: false,
+      ext: ".page.js",
+      path: "/pages/page2",
+      remote: undefined,
+    },
+  },
+  {
+    content: "document.querySelector('.dynamic-js')
+  .addEventListener('click', (event) => {
+    event.target.classList.add('dynamic-jssub-open');
+  });
+",
+    data: {
+      basename: "script",
+      content: "document.querySelector('.dynamic-js')
+  .addEventListener('click', (event) => {
+    event.target.classList.add('dynamic-jssub-open');
+  });
+",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      url: "/script.js",
+    },
+    src: {
+      asset: true,
+      ext: ".js",
+      path: "/script",
+      remote: undefined,
+    },
+  },
+  {
+    content: "::root {
+  --font-family: sans-serif;
+}
+
+body {
+  font-family: sans-serif;
+  color: black;
+}
+
+strong {
+  font-weight: bolder;
+}
+
+ html > * .content-vento {
+  max-width: 800px;
+}
+
+.content-vento:not(.test):focus-visible {
+  outline: 2px solid blue;
+}
+
+.content-dynamic {
+  display: flex;
+}
+
+.content-dynamic:focus-visible {
+  outline: 2px solid lightblue;
+}
+
+.dynamic-js {
+  opacity: 0;
+}
+
+.dynamic-jssub-open {
+  opacity: 1;
+}
+",
+    data: {
+      basename: "styles",
+      content: "::root {
+  --font-family: sans-serif;
+}
+
+body {
+  font-family: sans-serif;
+  color: black;
+}
+
+.unused {
+  margin-top: 30px;
+}
+
+strong {
+  font-weight: bolder;
+}
+
+em {
+  font-style: italic;
+}
+
+a[href] {
+  text-decoration: underline;
+}
+
+html > body .no-such-element .content-vento, html > * .content-vento {
+  max-width: 800px;
+}
+
+.content-vento:not(.test):focus-visible {
+  outline: 2px solid blue;
+}
+
+.content-dynamic {
+  display: flex;
+}
+
+.content-dynamic:focus-visible {
+  outline: 2px solid lightblue;
+}
+
+.content-static {
+  margin-top: 25px;
+}
+
+.content-other {
+  padding: 20px 5px;
+}
+
+.dynamic-js {
+  opacity: 0;
+}
+
+.dynamic-jssub {
+  display: none;
+}
+
+.dynamic-jssub-open {
+  opacity: 1;
+}
+
+#img-option {
+  max-width: 100%;
+}
+",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      url: "/styles.css",
+    },
+    src: {
+      asset: true,
+      ext: ".css",
+      path: "/styles",
+      remote: undefined,
+    },
+  },
+]
+`;
+
+snapshot[`purgecss plugin with options 1`] = `
+{
+  formats: [
+    {
+      engines: 0,
+      ext: ".page.toml",
+      loader: [AsyncFunction: toml],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".page.ts",
+      loader: [AsyncFunction: module],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".page.js",
+      loader: [AsyncFunction: module],
+      pageType: "page",
+    },
+    {
+      engines: 0,
+      ext: ".page.jsonc",
+      loader: [AsyncFunction: json],
+      pageType: "page",
+    },
+    {
+      engines: 0,
+      ext: ".page.json",
+      loader: [AsyncFunction: json],
+      pageType: "page",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: 0,
+      ext: ".json",
+      loader: [AsyncFunction: json],
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: 0,
+      ext: ".jsonc",
+      loader: [AsyncFunction: json],
+    },
+    {
+      engines: 1,
+      ext: ".md",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      assetLoader: [AsyncFunction: text],
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".js",
+      loader: [AsyncFunction: module],
+      pageType: "asset",
+    },
+    {
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".ts",
+      loader: [AsyncFunction: module],
+    },
+    {
+      engines: 1,
+      ext: ".vento",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".vto",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      dataLoader: [AsyncFunction: toml],
+      engines: 0,
+      ext: ".toml",
+      loader: [AsyncFunction: toml],
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: 0,
+      ext: ".yaml",
+      loader: [AsyncFunction: yaml],
+      pageType: "page",
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: 0,
+      ext: ".yml",
+      loader: [AsyncFunction: yaml],
+      pageType: "page",
+    },
+    {
+      assetLoader: [AsyncFunction: text],
+      engines: undefined,
+      ext: ".css",
+      pageType: "asset",
+    },
+  ],
+  src: [
+    "/",
+    "/_includes",
+    "/_includes/footer.vto",
+    "/_includes/layout.vto",
+    "/index.vto",
+    "/pages",
+    "/pages/page1.md",
+    "/pages/page2.page.js",
+    "/script.js",
+    "/static",
+    "/static/static.html",
+    "/styles.css",
+  ],
+}
+`;
+
+snapshot[`purgecss plugin with options 2`] = `
+[
+  {
+    entry: "/static/static.html",
+    flags: [],
+    outputPath: "/static.html",
+  },
+]
+`;
+
+snapshot[`purgecss plugin with options 3`] = `
+[
+  {
+    content: '<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TÍTULO</title>
+</head>
+<body>
+  <h1>Título</h1>
+
+<strong>strong</strong>
+
+<div class="content-vento" tabindex="0">Content</div>
+
+
+  <footer>
+Título
+</footer>
+</body>
+</html>
+',
+    data: {
+      basename: "index",
+      children: '<h1>Título</h1>
+
+<strong>strong</strong>
+
+<div class="content-vento" tabindex="0">Content</div>
+',
+      content: '<h1>{{ title }}</h1>
+
+<strong>strong</strong>
+
+<div class="content-vento" tabindex="0">Content</div>
+',
+      date: [],
+      layout: "layout.vto",
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      title: "Título",
+      url: "/",
+    },
+    src: {
+      asset: false,
+      ext: ".vto",
+      path: "/index",
+      remote: undefined,
+    },
+  },
+  {
+    content: "<!DOCTYPE html>
+<p>Content of Page 1</p>
+",
+    data: {
+      basename: "page1",
+      children: "<p>Content of Page 1</p>
+",
+      content: "Content of Page 1
+",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      title: "Page 1",
+      url: "/pages/page1/",
+    },
+    src: {
+      asset: false,
+      ext: ".md",
+      path: "/pages/page1",
+      remote: undefined,
+    },
+  },
+  {
+    content: '<!DOCTYPE html>
+<div class="content-dynamic">Content of Page 2</div>',
+    data: {
+      basename: "page2",
+      children: '<div class="content-dynamic">Content of Page 2</div>',
+      content: '<div class="content-dynamic">Content of Page 2</div>',
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      title: "Page 2",
+      url: "/page_2/",
+    },
+    src: {
+      asset: false,
+      ext: ".page.js",
+      path: "/pages/page2",
+      remote: undefined,
+    },
+  },
+  {
+    content: "document.querySelector('.dynamic-js')
+  .addEventListener('click', (event) => {
+    event.target.classList.add('dynamic-jssub-open');
+  });
+",
+    data: {
+      basename: "script",
+      content: "document.querySelector('.dynamic-js')
+  .addEventListener('click', (event) => {
+    event.target.classList.add('dynamic-jssub-open');
+  });
+",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      url: "/script.js",
+    },
+    src: {
+      asset: true,
+      ext: ".js",
+      path: "/script",
+      remote: undefined,
+    },
+  },
+  {
+    content: "::root {
+}
+
+body {
+  font-family: sans-serif;
+  color: black;
+}
+
+.unused {
+  margin-top: 30px;
+}
+
+ html > * .content-vento {
+  max-width: 800px;
+}
+
+.content-vento:not(.test):focus-visible {
+  outline: 2px solid blue;
+}
+
+.content-dynamic {
+  display: flex;
+}
+
+.content-dynamic:focus-visible {
+  outline: 2px solid lightblue;
+}
+
+.content-static {
+  margin-top: 25px;
+}
+
+.dynamic-js {
+  opacity: 0;
+}
+
+.dynamic-jssub-open {
+  opacity: 1;
+}
+
+#img-option {
+  max-width: 100%;
+}
+",
+    data: {
+      basename: "styles",
+      content: "::root {
+  --font-family: sans-serif;
+}
+
+body {
+  font-family: sans-serif;
+  color: black;
+}
+
+.unused {
+  margin-top: 30px;
+}
+
+strong {
+  font-weight: bolder;
+}
+
+em {
+  font-style: italic;
+}
+
+a[href] {
+  text-decoration: underline;
+}
+
+html > body .no-such-element .content-vento, html > * .content-vento {
+  max-width: 800px;
+}
+
+.content-vento:not(.test):focus-visible {
+  outline: 2px solid blue;
+}
+
+.content-dynamic {
+  display: flex;
+}
+
+.content-dynamic:focus-visible {
+  outline: 2px solid lightblue;
+}
+
+.content-static {
+  margin-top: 25px;
+}
+
+.content-other {
+  padding: 20px 5px;
+}
+
+.dynamic-js {
+  opacity: 0;
+}
+
+.dynamic-jssub {
+  display: none;
+}
+
+.dynamic-jssub-open {
+  opacity: 1;
+}
+
+#img-option {
+  max-width: 100%;
+}
+",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      url: "/styles.css",
+    },
+    src: {
+      asset: true,
+      ext: ".css",
+      path: "/styles",
+      remote: undefined,
+    },
+  },
+]
+`;

--- a/tests/assets/purgecss/_includes/footer.vto
+++ b/tests/assets/purgecss/_includes/footer.vto
@@ -1,0 +1,3 @@
+<footer>
+{{ title }}
+</footer>

--- a/tests/assets/purgecss/_includes/layout.vto
+++ b/tests/assets/purgecss/_includes/layout.vto
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ title |> toUpperCase }}</title>
+</head>
+<body>
+  {{ content }}
+
+  {{ include "footer.vto" }}
+</body>
+</html>

--- a/tests/assets/purgecss/index.vto
+++ b/tests/assets/purgecss/index.vto
@@ -1,0 +1,10 @@
+---
+title: Título
+layout: layout.vto
+---
+
+<h1>{{ title }}</h1>
+
+<strong>strong</strong>
+
+<div class="content-vento" tabindex="0">Content</div>

--- a/tests/assets/purgecss/pages/page1.md
+++ b/tests/assets/purgecss/pages/page1.md
@@ -1,0 +1,5 @@
+---
+title: Page 1
+---
+
+Content of Page 1

--- a/tests/assets/purgecss/pages/page2.page.js
+++ b/tests/assets/purgecss/pages/page2.page.js
@@ -1,0 +1,5 @@
+export const title = "Page 2";
+
+export const url = "/page_2/";
+
+export default `<div class="content-dynamic">Content of ${title}</div>`;

--- a/tests/assets/purgecss/script.js
+++ b/tests/assets/purgecss/script.js
@@ -1,0 +1,4 @@
+document.querySelector('.dynamic-js')
+  .addEventListener('click', (event) => {
+    event.target.classList.add('dynamic-jssub-open');
+  });

--- a/tests/assets/purgecss/static/static.html
+++ b/tests/assets/purgecss/static/static.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ title |> toUpperCase }}</title>
+</head>
+<body>
+  <div class="content-static">Content</div>
+</body>
+</html>

--- a/tests/assets/purgecss/styles.css
+++ b/tests/assets/purgecss/styles.css
@@ -1,0 +1,64 @@
+::root {
+  --font-family: sans-serif;
+}
+
+body {
+  font-family: sans-serif;
+  color: black;
+}
+
+.unused {
+  margin-top: 30px;
+}
+
+strong {
+  font-weight: bolder;
+}
+
+em {
+  font-style: italic;
+}
+
+a[href] {
+  text-decoration: underline;
+}
+
+html > body .no-such-element .content-vento, html > * .content-vento {
+  max-width: 800px;
+}
+
+.content-vento:not(.test):focus-visible {
+  outline: 2px solid blue;
+}
+
+.content-dynamic {
+  display: flex;
+}
+
+.content-dynamic:focus-visible {
+  outline: 2px solid lightblue;
+}
+
+.content-static {
+  margin-top: 25px;
+}
+
+.content-other {
+  padding: 20px 5px;
+}
+
+.dynamic-js {
+  opacity: 0;
+}
+
+.dynamic-jssub {
+  display: none;
+}
+
+.dynamic-jssub-open {
+  opacity: 1;
+}
+
+#img-option {
+  max-width: 100%;
+}

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -43,6 +43,7 @@ Deno.test("Plugins list in init", () => {
     "postcss",
     "prism",
     "pug",
+    "purgecss",
     "reading_info",
     "redirects",
     "relations",

--- a/tests/purgecss.test.ts
+++ b/tests/purgecss.test.ts
@@ -1,0 +1,44 @@
+import { assertSiteSnapshot, build, getPath, getSite } from "./utils.ts";
+import { normalizePath } from "../core/utils/path.ts";
+import purgecss from "../plugins/purgecss.ts";
+
+Deno.test("purgecss plugin", async (t) => {
+  const site = getSite({
+    src: "purgecss",
+  });
+
+  site.loadAssets([".css", ".js"]);
+  site.copy("static", ".");
+
+  site.use(purgecss());
+
+  await build(site);
+  await assertSiteSnapshot(t, site);
+});
+
+Deno.test("purgecss plugin with options", async (t) => {
+  const site = getSite({
+    src: "purgecss",
+  });
+
+  site.loadAssets([".css", ".js"]);
+  site.copy("static", ".");
+
+  site.use(purgecss({
+    options: {
+      content: [
+        normalizePath(getPath("./assets/purgecss/static/**/*.html")),
+        {
+          raw: '<img id="img-option" src="">',
+          extension: "html",
+        },
+      ],
+      safelist: ["unused"],
+      blocklist: ["strong"],
+      variables: true,
+    },
+  }));
+
+  await build(site);
+  await assertSiteSnapshot(t, site);
+});


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Adds a plugin for [PurgeCSS](https://purgecss.com/). This has several advantages over using PurgeCSS via the PostCSS plugin:

- Scan generated HTML (from plugins, Headless CMS or an API)
- Scan bundled JS dependencies (bootstrap, etc.)
- Only include CSS that is actually necessary (don't include drafts or conditional HTML that does not make it into the build)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
