### PR TITLE
Fix typo in code comment about the Satori library

### DIFF
--- a/plugins/og_images.ts
+++ b/plugins/og_images.ts
@@ -25,7 +25,7 @@ export interface Options {
   cache: string | boolean;
 
   /**
-   * The options for Satory to generate the SVG image.
+   * The options for Satori to generate the SVG image.
    * @see https://github.com/vercel/satori
    */
   satori?: SatoriOptions;


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Follow up to https://github.com/lumeland/lume.land/pull/147 which fixed the textual errors in the Lume documentation, this fixes the option comment (which is also displayed on the site)

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

https://github.com/lumeland/lume.land/pull/147

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [ ] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
