### PR TITLE
Fix icon plugin for custom catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ### Fixed
 - Updated deps: `sass`, `preact`, `xml`, `katex`, `jsr`, `pagefind`, `highlight.js`, `tailwindcss`, `magic-string` and some icons.
 - `esbuild`: JSR using import maps [#706].
+- `icons` plugin: Bug when using custom catalog for options
 
 ## [2.4.3] - 2024-12-11
 ### Added

--- a/plugins/icons.ts
+++ b/plugins/icons.ts
@@ -27,7 +27,7 @@ export function icons(userOptions?: Options) {
     site.filter("icon", icon);
 
     function icon(key: string, catalogId: string, rest?: string) {
-      const catalog = catalogs.find((c) => c.id === catalogId);
+      const catalog = options.catalogs.find((c) => c.id === catalogId);
 
       if (!catalog) {
         throw new Error(`Catalog "${catalogId}" not found`);


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Fixes a small bug I encountered in the `icons` plugin when using a custom catalog (specifically: [Skill Icons](https://skillicons.dev)). See this example:

```js
site.use(icons(
  {
    catalogs: [
      {
        id: "skill-icon",
        src: "https://skillicons.dev/icons?i={name}&theme={variant}",
        variants: [
          "dark",
          "light",
        ],
      },
    ],
  },
));
```

Upon running the website, Lume would return `> Catalog "skill-icon" not found`. 

I traced the issue in the `plugins/icons.ts` to a missing `options` when attempting to get the catalog (line 30). Replace `catalogs` with `options.catalogs` fixes the issue.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
