### PR TITLE
Add integrity hash to hot reload inline script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 - `prism` plugin: Added `cssFile` and `placeholder` option to themes.
 - `code_highlight` plugin: Added `cssFile` and `placeholder` option to themes.
 - `pagefind` plugin: New `ui.globalVariable` option.
+- Hot reload inline script tag includes integrity hash.
 
 ### Changed
 - Files with extension `.d.ts` are ignored by default [#707].

--- a/middlewares/reload.ts
+++ b/middlewares/reload.ts
@@ -1,4 +1,4 @@
-import { encodeBase64 } from "jsr:@std/encoding@1.0.5/base64";
+import { encodeBase64 } from "../deps/base64.ts";
 
 import { normalizePath } from "../core/utils/path.ts";
 import reloadClient from "./reload_client.js";


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

I have been working on adding strict CSP rules to my website.

Although the hot reload script is only present during development, the strict CSP rules end up blocking the hot reload script from running at all. Plus, it generates some noise in the developer tools console:

> Refused to execute inline script because it violates the following Content Security Policy directive: "script-src-elem 'self' https://esm.sh". Either the 'unsafe-inline' keyword, a hash ('sha256-C2A/zAnUiwX3gOwj8Fa3vHcIis+esAeDAmnu4aN5OSE='), or a nonce ('nonce-...') is required to enable inline execution.

This diff adds the corresponding integrity hash property to the injected script tag.

## Related Issues

N/A

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
