### PR TITLE
jsx_preact: Add type for `Lume.Data.children`

### DIFF
--- a/plugins/jsx_preact.ts
+++ b/plugins/jsx_preact.ts
@@ -120,15 +120,27 @@ export function jsxPreact(userOptions?: Options) {
 
 export default jsxPreact;
 
-/** Extends HTMLAttributes interface */
 declare global {
   namespace preact.JSX {
+    /** Extends HTMLAttributes interface */
     interface HTMLAttributes {
       /** Custom attribute used by inline plugin */
       inline?: boolean | undefined;
 
       /** Custom attribute used by transform images plugin */
       "transform-images"?: string | undefined;
+    }
+  }
+
+  /** Extends Data interface */
+  namespace Lume {
+    export interface Data {
+      /**
+       * The JSX children elements
+       * @see https://lume.land/plugins/jsx_preact/
+       */
+      // @ts-ignore - jsx and jsx_preact conflict
+      children?: preact.ComponentChildren;
     }
   }
 }


### PR DESCRIPTION
## Description

The `jsx_preact` plugin adds a type for the `children` field on `Lume.Data`. Unfortunately, this doesn't pass tests because it conflicts with the `children` field added by the `jsx` plugin. Is there a way to move forward with this? My project of course only uses the `jsx_preact` plugin, so I get no type annotations for the `children` field.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
