### PR TITLE
Feed plugin: Add options info.image, info.icon and info.color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Go to the `v1` branch to see the changelog of Lume 1.
 - New `--hostname` argument to `lume --serve` and `lume cms` to change the default
   `localhost` value to something else.
 - New `--open, -o` argument to `lume cms` to open automatically in the browser.
+- Feed plugin
+  - New option `info.image`
+  - New option `info.icon`
+  - New option `info.color`
 
 ### Changed
 - `inline`: Append classes to existing ones. [#722]

--- a/plugins/feed.ts
+++ b/plugins/feed.ts
@@ -56,6 +56,15 @@ export interface FeedInfoOptions {
 
   /** The feed author URL */
   authorUrl?: string;
+
+  /** The main image of the site */
+  image?: string;
+
+  /** The logotype or icon of the site */
+  icon?: string;
+
+  /** The color theme of the site */
+  color?: string;
 }
 
 export interface FeedItemOptions {
@@ -131,6 +140,9 @@ export interface FeedData {
   generator?: string;
   items: FeedItem[];
   author?: Author;
+  image?: string;
+  icon?: string;
+  color?: string;
 }
 
 export interface FeedItem {
@@ -179,6 +191,9 @@ export function feed(userOptions?: Options) {
           ? defaultGenerator
           : info.generator || undefined,
         author: getAuthor(rootData, info),
+        image: info.image,
+        icon: info.icon,
+        color: info.color,
         items: pages.map((data): FeedItem => {
           const content = getDataValue(data, items.content)?.toString();
           const pageUrl = site.url(data.url, true);
@@ -260,6 +275,7 @@ function generateRss(data: FeedData, file: string): string {
       "@xmlns:atom": "http://www.w3.org/2005/Atom",
       "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
       "@xmlns:slash": "http://purl.org/rss/1.0/modules/slash/",
+      "@xmlns:webfeeds": "http://webfeeds.org/rss/1.0",
       "@version": "2.0",
       channel: {
         title: data.title,
@@ -277,6 +293,11 @@ function generateRss(data: FeedData, file: string): string {
           name: data.author?.name,
           uri: data.author?.url,
         },
+        "webfeeds:cover": {
+          "@image": data.image,
+        },
+        "webfeeds:logo": data.icon,
+        "webfeeds:accentColor": data.color,
         item: data.items.map((item) => ({
           title: item.title,
           link: item.url,
@@ -311,6 +332,8 @@ function generateJson(data: FeedData, file: string): string {
     feed_url: file,
     description: data.description,
     author: data.author,
+    icon: data.image,
+    favicon: data.icon,
     items: data.items.map((item) => ({
       id: item.url,
       url: item.url,

--- a/tests/__snapshots__/feed.test.ts.snap
+++ b/tests/__snapshots__/feed.test.ts.snap
@@ -117,10 +117,10 @@ snapshot[`RSS plugin 2`] = `[]`;
 snapshot[`RSS plugin 3`] = `
 [
   {
-    content: '{"version":"https://jsonfeed.org/version/1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","author":{"name":"Laura Rubio"},"items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","author":{"name":"Óscar","url":"https://oscarotero.com"},"content_html":"Content of Page 5","date_published":"Thu, 21 Jun 1979 23:45:00 GMT","date_modified":"Thu, 21 Jun 1979 23:45:00 GMT"}]}',
+    content: '{"version":"https://jsonfeed.org/version/1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","author":{"name":"Laura Rubio"},"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","author":{"name":"Óscar","url":"https://oscarotero.com"},"content_html":"Content of Page 5","date_published":"Thu, 21 Jun 1979 23:45:00 GMT","date_modified":"Thu, 21 Jun 1979 23:45:00 GMT"}]}',
     data: {
       basename: "feed",
-      content: '{"version":"https://jsonfeed.org/version/1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","author":{"name":"Laura Rubio"},"items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","author":{"name":"Óscar","url":"https://oscarotero.com"},"content_html":"Content of Page 5","date_published":"Thu, 21 Jun 1979 23:45:00 GMT","date_modified":"Thu, 21 Jun 1979 23:45:00 GMT"}]}',
+      content: '{"version":"https://jsonfeed.org/version/1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","author":{"name":"Laura Rubio"},"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","author":{"name":"Óscar","url":"https://oscarotero.com"},"content_html":"Content of Page 5","date_published":"Thu, 21 Jun 1979 23:45:00 GMT","date_modified":"Thu, 21 Jun 1979 23:45:00 GMT"}]}',
       page: [
         "src",
         "data",
@@ -137,7 +137,7 @@ snapshot[`RSS plugin 3`] = `
   },
   {
     content: '<?xml version="1.0" encoding="UTF-8"?>
-<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:slash="http://purl.org/rss/1.0/modules/slash/" version="2.0">
+<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:slash="http://purl.org/rss/1.0/modules/slash/" xmlns:webfeeds="http://webfeeds.org/rss/1.0" version="2.0">
   <channel>
     <title>My RSS Feed</title>
     <link>https://example.com/</link>
@@ -148,6 +148,9 @@ snapshot[`RSS plugin 3`] = `
     <author>
       <name>Laura Rubio</name>
     </author>
+    <webfeeds:cover image="https://example.com/image.png"/>
+    <webfeeds:logo>https://example.com/icon.svg</webfeeds:logo>
+    <webfeeds:accentColor>#ff0000</webfeeds:accentColor>
     <item>
       <title>PAGE 5</title>
       <link>https://example.com/page5/</link>
@@ -165,7 +168,7 @@ snapshot[`RSS plugin 3`] = `
     data: {
       basename: "feed",
       content: '<?xml version="1.0" encoding="UTF-8"?>
-<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:slash="http://purl.org/rss/1.0/modules/slash/" version="2.0">
+<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:slash="http://purl.org/rss/1.0/modules/slash/" xmlns:webfeeds="http://webfeeds.org/rss/1.0" version="2.0">
   <channel>
     <title>My RSS Feed</title>
     <link>https://example.com/</link>
@@ -176,6 +179,9 @@ snapshot[`RSS plugin 3`] = `
     <author>
       <name>Laura Rubio</name>
     </author>
+    <webfeeds:cover image="https://example.com/image.png"/>
+    <webfeeds:logo>https://example.com/icon.svg</webfeeds:logo>
+    <webfeeds:accentColor>#ff0000</webfeeds:accentColor>
     <item>
       <title>PAGE 5</title>
       <link>https://example.com/page5/</link>

--- a/tests/feed.test.ts
+++ b/tests/feed.test.ts
@@ -14,6 +14,9 @@ Deno.test("RSS plugin", async (t) => {
         published: new Date("2020-01-01"),
         generator: "https://lume.land",
         authorName: "Laura Rubio",
+        icon: "https://example.com/icon.svg",
+        image: "https://example.com/image.png",
+        color: "#ff0000",
       },
       items: {
         title: (data) => data.title?.toUpperCase(),


### PR DESCRIPTION
## Description

Add option to add custom fields to RSS feed output. This can be used as extended metadata for Feedly, for example.

refs:

* https://devhd.wordpress.com/2015/07/31/10-ways-to-optimize-your-feed-for-feedly/
* https://justingarrison.com/blog/2022-11-22-hugo-rss-improvements/
* https://github.com/withastro/astro/tree/main/packages/astro-rss#customdata

## Related Issues

## Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
