### PR TITLE
Feed plugin: Add options for `info.hubs` (WebSub support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project try to adheres to [Semantic Versioning](https://semver.org/).
 Go to the `v1` branch to see the changelog of Lume 1.
 
+## [Unreleased]
+### Added
+- Feed plugin
+  - New option `info.hubs`
+
 ## [2.5.1] - 2025-01-28
 ### Added
 - Support for LumeCMS v0.9, that can perform git operations and restart the build.

--- a/tests/__snapshots__/feed.test.ts.snap
+++ b/tests/__snapshots__/feed.test.ts.snap
@@ -117,10 +117,10 @@ snapshot[`RSS plugin 2`] = `[]`;
 snapshot[`RSS plugin 3`] = `
 [
   {
-    content: '{"version":"https://jsonfeed.org/version/1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","author":{"name":"Laura Rubio"},"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","author":{"name":"Óscar","url":"https://oscarotero.com"},"content_html":"Content of Page 5","date_published":"Thu, 21 Jun 1979 23:45:00 GMT","date_modified":"Thu, 21 Jun 1979 23:45:00 GMT"}]}',
+    content: '{"version":"https://jsonfeed.org/version/1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","hubs":[{"type":"WebSub","feed_url":"https://example.com/hub1"},{"type":"WebSub","feed_url":"https://example.com/hub2"}],"author":{"name":"Laura Rubio"},"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","author":{"name":"Óscar","url":"https://oscarotero.com"},"content_html":"Content of Page 5","date_published":"Thu, 21 Jun 1979 23:45:00 GMT","date_modified":"Thu, 21 Jun 1979 23:45:00 GMT"}]}',
     data: {
       basename: "feed",
-      content: '{"version":"https://jsonfeed.org/version/1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","author":{"name":"Laura Rubio"},"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","author":{"name":"Óscar","url":"https://oscarotero.com"},"content_html":"Content of Page 5","date_published":"Thu, 21 Jun 1979 23:45:00 GMT","date_modified":"Thu, 21 Jun 1979 23:45:00 GMT"}]}',
+      content: '{"version":"https://jsonfeed.org/version/1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","hubs":[{"type":"WebSub","feed_url":"https://example.com/hub1"},{"type":"WebSub","feed_url":"https://example.com/hub2"}],"author":{"name":"Laura Rubio"},"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","author":{"name":"Óscar","url":"https://oscarotero.com"},"content_html":"Content of Page 5","date_published":"Thu, 21 Jun 1979 23:45:00 GMT","date_modified":"Thu, 21 Jun 1979 23:45:00 GMT"}]}',
       page: [
         "src",
         "data",
@@ -142,6 +142,8 @@ snapshot[`RSS plugin 3`] = `
     <title>My RSS Feed</title>
     <link>https://example.com/</link>
     <atom:link href="https://example.com/feed.rss" rel="self" type="application/rss+xml"/>
+    <atom:link href="https://example.com/hub1" rel="hub"/>
+    <atom:link href="https://example.com/hub2" rel="hub"/>
     <lastBuildDate>Wed, 01 Jan 2020 00:00:00 GMT</lastBuildDate>
     <language>en</language>
     <generator>https://lume.land</generator>
@@ -173,6 +175,8 @@ snapshot[`RSS plugin 3`] = `
     <title>My RSS Feed</title>
     <link>https://example.com/</link>
     <atom:link href="https://example.com/feed.rss" rel="self" type="application/rss+xml"/>
+    <atom:link href="https://example.com/hub1" rel="hub"/>
+    <atom:link href="https://example.com/hub2" rel="hub"/>
     <lastBuildDate>Wed, 01 Jan 2020 00:00:00 GMT</lastBuildDate>
     <language>en</language>
     <generator>https://lume.land</generator>

--- a/tests/feed.test.ts
+++ b/tests/feed.test.ts
@@ -17,6 +17,7 @@ Deno.test("RSS plugin", async (t) => {
         icon: "https://example.com/icon.svg",
         image: "https://example.com/image.png",
         color: "#ff0000",
+        hubs: ["https://example.com/hub1", "https://example.com/hub2"],
       },
       items: {
         title: (data) => data.title?.toUpperCase(),


### PR DESCRIPTION
## Description

This PR updates the Feed plugin to add support for WebSub links.

For example, this is useful for broadcasting new content to search engines.

Refs:
- https://www.w3.org/TR/websub/
  - See [this note](https://www.w3.org/TR/websub/#h-note) for why `hubs` is an array and not a single string.
- https://www.jsonfeed.org/version/1/#subscribing-to-real-time-notifications
- https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap#addsitemap
  - >If you use Atom or RSS, you can use [WebSub](https://www.w3.org/TR/websub/) to broadcast your changes to search engines, including Google.

## Related Issues

N/A

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
