### PR TITLE
Redirects plugin: Add `is_redirect=true` data field to HTML redirect pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ## [Unreleased]
 ### Added
 - Feed plugin: New option `info.hubs` [#725].
-- Redirects plugin: Add `is_redirect=true` data field to HTML redirect pages.
+- Redirects plugin: Add `isRedirect=true` data field to HTML redirect pages.
 
 ### Fixed
 - Sass plugin: Allow additional importers [#727].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ### Added
 - Feed plugin: New option `info.hubs` [#725].
 - Redirects plugin: Add `isRedirect=true` data field to HTML redirect pages.
+- Sitemap plugin: Set default query to `isRedirect!=true`.
 
 ### Fixed
 - Sass plugin: Allow additional importers [#727].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ## [Unreleased]
 ### Added
 - Feed plugin: New option `info.hubs` [#725].
+- Redirects plugin: Add `is_redirect=true` data field to HTML redirect pages.
 
 ### Fixed
 - Sass plugin: Allow additional importers [#727].

--- a/plugins/redirects.ts
+++ b/plugins/redirects.ts
@@ -123,7 +123,7 @@ function html(redirects: Redirect[], site: Site): void {
   <a href="${to}">Click here if you are not redirected.</a>
 </body>
 </html>`;
-    const page = Page.create({ url, content });
+    const page = Page.create({ url, content, is_redirect: true });
     site.pages.push(page);
   }
 }

--- a/plugins/redirects.ts
+++ b/plugins/redirects.ts
@@ -123,7 +123,7 @@ function html(redirects: Redirect[], site: Site): void {
   <a href="${to}">Click here if you are not redirected.</a>
 </body>
 </html>`;
-    const page = Page.create({ url, content, is_redirect: true });
+    const page = Page.create({ url, content, isRedirect: true });
     site.pages.push(page);
   }
 }

--- a/plugins/sitemap.ts
+++ b/plugins/sitemap.ts
@@ -18,7 +18,10 @@ export interface Options {
   /** The sitemap file name */
   filename?: string;
 
-  /** The query to search pages included in the sitemap */
+  /**
+   * The query to search pages included in the sitemap
+   * @default "isRedirect!=true" excludes redirect pages produced by the redirects plugin
+   */
   query?: string;
 
   /** The values to sort the sitemap */
@@ -37,7 +40,7 @@ export interface Options {
 // Default options
 export const defaults: Options = {
   filename: "/sitemap.xml",
-  query: "",
+  query: "isRedirect!=true",
   sort: "url=asc",
   lastmod: "date",
 };

--- a/tests/__snapshots__/redirects.test.ts.snap
+++ b/tests/__snapshots__/redirects.test.ts.snap
@@ -141,6 +141,7 @@ snapshot[`redirects plugin 3`] = `
   <a href="/page1/">Click here if you are not redirected.</a>
 </body>
 </html>',
+      is_redirect: true,
       page: [
         "src",
         "data",
@@ -182,6 +183,7 @@ snapshot[`redirects plugin 3`] = `
   <a href="/page2/">Click here if you are not redirected.</a>
 </body>
 </html>',
+      is_redirect: true,
       page: [
         "src",
         "data",
@@ -223,6 +225,7 @@ snapshot[`redirects plugin 3`] = `
   <a href="/page2/">Click here if you are not redirected.</a>
 </body>
 </html>',
+      is_redirect: true,
       page: [
         "src",
         "data",

--- a/tests/__snapshots__/redirects.test.ts.snap
+++ b/tests/__snapshots__/redirects.test.ts.snap
@@ -141,7 +141,7 @@ snapshot[`redirects plugin 3`] = `
   <a href="/page1/">Click here if you are not redirected.</a>
 </body>
 </html>',
-      is_redirect: true,
+      isRedirect: true,
       page: [
         "src",
         "data",
@@ -183,7 +183,7 @@ snapshot[`redirects plugin 3`] = `
   <a href="/page2/">Click here if you are not redirected.</a>
 </body>
 </html>',
-      is_redirect: true,
+      isRedirect: true,
       page: [
         "src",
         "data",
@@ -225,7 +225,7 @@ snapshot[`redirects plugin 3`] = `
   <a href="/page2/">Click here if you are not redirected.</a>
 </body>
 </html>',
-      is_redirect: true,
+      isRedirect: true,
       page: [
         "src",
         "data",

--- a/tests/__snapshots__/sitemap.test.ts.snap
+++ b/tests/__snapshots__/sitemap.test.ts.snap
@@ -2244,11 +2244,11 @@ Sitemap: https://example.com/sitemap.xml",
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://example.com/page1/</loc>
-    <lastmod>2025-01-29T21:30:22.949Z</lastmod>
+    <lastmod>2025-02-04T20:00:00.000Z</lastmod>
   </url>
   <url>
     <loc>https://example.com/page2/</loc>
-    <lastmod>2025-01-29T21:30:22.949Z</lastmod>
+    <lastmod>2025-02-04T20:00:00.000Z</lastmod>
   </url>
 </urlset>',
     data: {
@@ -2257,11 +2257,11 @@ Sitemap: https://example.com/sitemap.xml",
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://example.com/page1/</loc>
-    <lastmod>2025-01-29T21:30:22.949Z</lastmod>
+    <lastmod>2025-02-04T20:00:00.000Z</lastmod>
   </url>
   <url>
     <loc>https://example.com/page2/</loc>
-    <lastmod>2025-01-29T21:30:22.949Z</lastmod>
+    <lastmod>2025-02-04T20:00:00.000Z</lastmod>
   </url>
 </urlset>',
       page: [

--- a/tests/__snapshots__/sitemap.test.ts.snap
+++ b/tests/__snapshots__/sitemap.test.ts.snap
@@ -1977,3 +1977,367 @@ Content of Page 4 in Overrided site name, from the file /pages/2021-01-02-18-32_
   },
 ]
 `;
+
+snapshot[`Sitemap plugin with redirects plugin 1`] = `
+{
+  formats: [
+    {
+      engines: 0,
+      ext: ".page.toml",
+      loader: [AsyncFunction: toml],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".page.ts",
+      loader: [AsyncFunction: module],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".page.js",
+      loader: [AsyncFunction: module],
+      pageType: "page",
+    },
+    {
+      engines: 0,
+      ext: ".page.jsonc",
+      loader: [AsyncFunction: json],
+      pageType: "page",
+    },
+    {
+      engines: 0,
+      ext: ".page.json",
+      loader: [AsyncFunction: json],
+      pageType: "page",
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: 0,
+      ext: ".json",
+      loader: [AsyncFunction: json],
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: 0,
+      ext: ".jsonc",
+      loader: [AsyncFunction: json],
+    },
+    {
+      engines: 1,
+      ext: ".md",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".js",
+      loader: [AsyncFunction: module],
+    },
+    {
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".ts",
+      loader: [AsyncFunction: module],
+    },
+    {
+      engines: 1,
+      ext: ".vento",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      engines: 1,
+      ext: ".vto",
+      loader: [AsyncFunction: text],
+      pageType: "page",
+    },
+    {
+      dataLoader: [AsyncFunction: toml],
+      engines: 0,
+      ext: ".toml",
+      loader: [AsyncFunction: toml],
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: 0,
+      ext: ".yaml",
+      loader: [AsyncFunction: yaml],
+      pageType: "page",
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: 0,
+      ext: ".yml",
+      loader: [AsyncFunction: yaml],
+      pageType: "page",
+    },
+  ],
+  src: [
+    "/",
+    "/page1.vto",
+    "/page2.vto",
+  ],
+}
+`;
+
+snapshot[`Sitemap plugin with redirects plugin 2`] = `[]`;
+
+snapshot[`Sitemap plugin with redirects plugin 3`] = `
+[
+  {
+    content: '<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting…</title>
+  <meta http-equiv="refresh" content="0; url=/page1/">
+</head>
+<body>
+  <h1>Redirecting…</h1>
+  <a href="/page1/">Click here if you are not redirected.</a>
+</body>
+</html>',
+    data: {
+      basename: "old-page1",
+      content: '<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting…</title>
+  <meta http-equiv="refresh" content="0; url=/page1/">
+</head>
+<body>
+  <h1>Redirecting…</h1>
+  <a href="/page1/">Click here if you are not redirected.</a>
+</body>
+</html>',
+      isRedirect: true,
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      url: "/old-page1/",
+    },
+    src: {
+      asset: true,
+      ext: "",
+      path: "",
+      remote: undefined,
+    },
+  },
+  {
+    content: '<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting…</title>
+  <meta http-equiv="refresh" content="0; url=/page2/">
+</head>
+<body>
+  <h1>Redirecting…</h1>
+  <a href="/page2/">Click here if you are not redirected.</a>
+</body>
+</html>',
+    data: {
+      basename: "old-page2",
+      content: '<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting…</title>
+  <meta http-equiv="refresh" content="0; url=/page2/">
+</head>
+<body>
+  <h1>Redirecting…</h1>
+  <a href="/page2/">Click here if you are not redirected.</a>
+</body>
+</html>',
+      isRedirect: true,
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      url: "/old-page2/",
+    },
+    src: {
+      asset: true,
+      ext: "",
+      path: "",
+      remote: undefined,
+    },
+  },
+  {
+    content: '<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting…</title>
+  <meta http-equiv="refresh" content="1; url=/page2/">
+</head>
+<body>
+  <h1>Redirecting…</h1>
+  <a href="/page2/">Click here if you are not redirected.</a>
+</body>
+</html>',
+    data: {
+      basename: "other-old-page2",
+      content: '<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting…</title>
+  <meta http-equiv="refresh" content="1; url=/page2/">
+</head>
+<body>
+  <h1>Redirecting…</h1>
+  <a href="/page2/">Click here if you are not redirected.</a>
+</body>
+</html>',
+      isRedirect: true,
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      url: "/other-old-page2/",
+    },
+    src: {
+      asset: true,
+      ext: "",
+      path: "",
+      remote: undefined,
+    },
+  },
+  {
+    content: "User-agent: *
+Allow: /
+
+Sitemap: https://example.com/sitemap.xml",
+    data: {
+      basename: "robots",
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      url: "/robots.txt",
+    },
+    src: {
+      asset: true,
+      ext: "",
+      path: "",
+      remote: undefined,
+    },
+  },
+  {
+    content: '<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://example.com/page1/</loc>
+    <lastmod>2025-01-29T21:30:22.949Z</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/page2/</loc>
+    <lastmod>2025-01-29T21:30:22.949Z</lastmod>
+  </url>
+</urlset>',
+    data: {
+      basename: "sitemap",
+      content: '<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://example.com/page1/</loc>
+    <lastmod>2025-01-29T21:30:22.949Z</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/page2/</loc>
+    <lastmod>2025-01-29T21:30:22.949Z</lastmod>
+  </url>
+</urlset>',
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      url: "/sitemap.xml",
+    },
+    src: {
+      asset: true,
+      ext: "",
+      path: "",
+      remote: undefined,
+    },
+  },
+  {
+    content: "<!DOCTYPE html>
+Page 1",
+    data: {
+      basename: "page1",
+      children: "Page 1",
+      content: "Page 1",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      oldUrl: "/old-page1/",
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      url: "/page1/",
+    },
+    src: {
+      asset: false,
+      ext: ".vto",
+      path: "/page1",
+      remote: undefined,
+    },
+  },
+  {
+    content: "<!DOCTYPE html>
+Page 2
+",
+    data: {
+      basename: "page2",
+      children: "Page 2
+",
+      content: "Page 2
+",
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      oldUrl: "Array(2)",
+      page: [
+        "src",
+        "data",
+        "asset",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      url: "/page2/",
+    },
+    src: {
+      asset: false,
+      ext: ".vto",
+      path: "/page2",
+      remote: undefined,
+    },
+  },
+]
+`;

--- a/tests/assets/redirects/page1.vto
+++ b/tests/assets/redirects/page1.vto
@@ -1,5 +1,6 @@
 ---
 url: /page1/
+date: 2025-02-04T20:00Z
 oldUrl: /old-page1/
 ---
 

--- a/tests/assets/redirects/page2.vto
+++ b/tests/assets/redirects/page2.vto
@@ -1,4 +1,5 @@
 ---
+date: 2025-02-04T20:00Z
 oldUrl:
   - /old-page2/
   - /other-old-page2/ 307

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -2,6 +2,7 @@ import { assertSiteSnapshot, build, getSite } from "./utils.ts";
 import sitemap from "../plugins/sitemap.ts";
 import multilanguage from "../plugins/multilanguage.ts";
 import filterPages from "../plugins/filter_pages.ts";
+import redirects from "../plugins/redirects.ts";
 
 Deno.test("Sitemap plugin", async (t) => {
   const site = getSite({
@@ -45,6 +46,19 @@ Deno.test("Sitemap plugin with filter_pages plugin", async (t) => {
   site.use(filterPages({
     fn: (page) => page.data.url !== "/pages/new-name/page7/",
   }));
+
+  await build(site);
+  await assertSiteSnapshot(t, site);
+});
+
+Deno.test("Sitemap plugin with redirects plugin", async (t) => {
+  const site = getSite({
+    src: "redirects",
+    location: new URL("https://example.com/"),
+  });
+
+  site.use(sitemap());
+  site.use(redirects());
 
   await build(site);
   await assertSiteSnapshot(t, site);


### PR DESCRIPTION
## Description

I want to hide redirect pages from my sitemap, and this small addition would help me like so:

```typescript
site.use(sitemap({ query: "is_redirect!=true" }));
```

I am not sure if there is a different preferred way to approach this. Please let me know 🙏 

## Related Issues

N/A

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
