### PR TITLE
middlewares/reload: use site's location pathname as websocket basepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 - Sass plugin: Allow additional importers [#727].
 - Components: Reorder css code to ensure `@import` rules are first.
 - Updated components: `std`, `decap-cms`, `terser` and some icons.
+- Hot reload: use site's location pathname as websocket basepath
 
 ## [2.5.1] - 2025-01-28
 ### Added

--- a/cli/build_worker.ts
+++ b/cli/build_worker.ts
@@ -102,7 +102,10 @@ async function build({ type, config, serve }: BuildOptions) {
   }
 
   server.use(
-    reload({ watcher: new SiteWatcher(site) }),
+    reload({
+      watcher: new SiteWatcher(site),
+      basepath: site.options.location.pathname,
+    }),
     noCache(),
     noCors(),
     notFound({

--- a/middlewares/reload.ts
+++ b/middlewares/reload.ts
@@ -8,6 +8,7 @@ import type { Watcher } from "../core/watcher.ts";
 
 export interface Options {
   watcher: Watcher;
+  basepath: string;
 }
 
 /** Middleware to hot reload changes */
@@ -96,7 +97,8 @@ export function reload(options: Options): Middleware {
         result = await reader.read();
       }
 
-      const source = `${reloadClient}; liveReload(${revision});`;
+      const source =
+        `${reloadClient}; liveReload(${revision}, "${options.basepath}");`;
       const integrity = await computeSourceIntegrity(source);
 
       // Add live reload script and pass initial revision

--- a/middlewares/reload_client.js
+++ b/middlewares/reload_client.js
@@ -1,4 +1,4 @@
-export default function liveReload(initRevision) {
+export default function liveReload(initRevision, basepath) {
   let ws;
   let wasClosed = false;
   let revision = initRevision;
@@ -10,7 +10,7 @@ export default function liveReload(initRevision) {
     const protocol = document.location.protocol === "https:"
       ? "wss://"
       : "ws://";
-    ws = new WebSocket(protocol + document.location.host);
+    ws = new WebSocket(protocol + document.location.host + basepath);
     ws.onopen = () => {
       console.log("Lume live reloading is ready. Listening for changes...");
 


### PR DESCRIPTION
## Description

I know that this is very much an edge case but.. I noticed that the websocket client code in the hot reload module does not honor the `location` path.

For example: when I have `--location=https://mysite/subpath/`, then the websocket client connects to `wss://mysite/` and not `wss://mysite/subpath/` as I'd expect.

I ran into this while using Apache as a proxy to the Lume dev server like so:
```
RewriteEngine on

RewriteCond %{HTTP:Upgrade} websocket [NC]
RewriteCond %{HTTP:Connection} upgrade [NC]
RewriteRule ^/?lume/(.*)$ "ws://127.0.0.1:3000/$1" [P,L]

RewriteRule ^/?lume/(.*)$ "http://127.0.0.1:3000/$1" [P,L]
```
And running Lume like so:
```
deno task serve --location="https://mysite.com/lume/" --hostname=localhost --port=3000
```
For the time being, I just do the following. Though, it is limiting if I tried to develop more than one app at a time.
```
RewriteRule ^/?(.*) "ws://localhost:3000/$1" [P,L]
```
I understand that the dev server is for local use only and that it rightly expects to be accessed via `http://localhost:3000/` (root path) for 99% of use cases. But the `serve` command _does_ accept the `--location` argument and it worked well with the proxying above. It's just the websocket part that broke my expectations.

wdyt?

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
