### PR TITLE
fix(plugins/metas): set locale correctly (if set)

### DIFF
--- a/plugins/metas.ts
+++ b/plugins/metas.ts
@@ -110,7 +110,12 @@ export function metas(userOptions?: Options) {
       // Open graph
       addMeta(document, "property", "og:type", type || "website");
       addMeta(document, "property", "og:site_name", site_name);
-      addMeta(document, "property", "og:locale", lang);
+      addMeta(
+        document,
+        "property",
+        "og:locale",
+        typeof lang === "string" ? lang.replace("-", "_") : lang,
+      );
       addMeta(document, "property", "og:title", title, 65);
       addMeta(document, "property", "og:description", description, 155);
       addMeta(document, "property", "og:url", url);


### PR DESCRIPTION
## Description

This will set the `og:locale` to `language_TERRITORY` as required by the [spec](https://ogp.me/#optional). The `lang` can be `undefined` (not set), in which case `og:locale` is not set by the plugin either.

Some tests are failing locally, but they’re not related to the Metas plugin (AFAICT).

**PS**: LMK if this change requires a test. I’ll look into it at that point.

## Related Issues

Fixes #729.

### Check List

- [x] Have you read the [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing, send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
