### PR TITLE
feat: add option to throw if check_urls plugin fails

### DIFF
--- a/plugins/check_urls.ts
+++ b/plugins/check_urls.ts
@@ -14,6 +14,9 @@ export interface Options {
   /** True to require trailing slashes and ignore redirections (oldUrl variables) */
   strict?: boolean;
 
+  /** True to throw if an invalid url is found */
+  throw?: boolean;
+
   /** The list of URLs to ignore */
   ignore?: string[];
 
@@ -28,6 +31,7 @@ export interface Options {
 export const defaults: Options = {
   extensions: [".html"],
   strict: false,
+  throw: false,
   ignore: [],
   external: false,
 };
@@ -184,6 +188,10 @@ export default function (userOptions?: Options) {
       cacheInternalUrls.clear();
       urls.clear();
       redirects.clear();
+
+      if (notFound.size > 0 && options.throw) {
+        throw `${notFound.size} broken link(s)`;
+      }
     }
 
     site.addEventListener("afterUpdate", checkUrls);
@@ -278,7 +286,7 @@ function outputConsole(notFound: Map<string, Set<string>>) {
   }
 
   console.log("");
-  console.log(`${notFound.size} Broken links:`);
+  console.log(`${notFound.size} broken link(s):`);
   for (const [url, refs] of notFound) {
     console.log("");
     console.log("⛓️‍💥", red(url));


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
The `check_urls` plugin by default reports broken urls but it doesn't stop builds. It would be nice to have the option to throw to immediately stop builds. For example, stopping CI/deployment if an invalid url exists.

## Related Issues

n/a

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
