### PR TITLE
Add macos-15 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,8 @@ jobs:
           - latest
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-latest # macos-14
+          - macos-15
           - windows-latest
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
As I investigated #759, I found that `macos-latest` implies `macos-14`.

macOS 14.x  has an estimated less than 20% market share compared to macOS 15.x's 80%+.

Source: https://telemetrydeck.com/survey/apple/macOS/versions/