### PR TITLE
Add a try-catch to the Katex plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ## [3.0.6] - Unreleased
 ### Fixed
 - `jsx` plugin: Support `precompile` option [#770]
+- `katex` plugin: Catch Katex errors when delimiters are allowed
 
 ## [3.0.5] - 2025-07-17
 ### Changed

--- a/plugins/katex.ts
+++ b/plugins/katex.ts
@@ -139,7 +139,13 @@ export function katex(userOptions?: Options) {
           });
 
         if (options.options.delimiters) {
-          renderMathInElement(document.body, options.options);
+          try {
+            renderMathInElement(document.body, options.options);
+          } catch (cause) {
+            log.error(
+              `[katex plugin] Failed to render math in ${page.outputPath}: ${cause}`,
+            );
+          }
         }
       }
     });


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

Hello, thank you for a wonderful static site generator. I've been using it for a few years, and I've enjoyed working with it very much. :3

## Description

When one uses the Katex plugin **with delimiters**, sometimes it can crash the whole build/watch process because Katex's `renderMathInElement` is not in a try-catch like `Katex.renderToString` is, so I've added that. (The `throwOnError` option is of little help, since [that only applies to `ParseError`s](https://github.com/KaTeX/KaTeX/issues/3680).)

## Related Issues

None that I could find.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests. (IMHO no tests needed for change this little.)
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
