### PR TITLE
fix(google_fonts): handle unnamed @font-face subsets

### DIFF
--- a/plugins/google_fonts.ts
+++ b/plugins/google_fonts.ts
@@ -114,10 +114,11 @@ interface FontFace {
 }
 
 function extractFontFaces(css: string, name: string): FontFace[] {
-  const fontFaces = css.match(/\/\*[^*]+\*\/[\s]+@font-face {[^}]+}/g) || [];
+  const fontFaces = css.match(/(\/\*[^*]+\*\/)?[\s]+@font-face {[^}]+}/g) || [];
 
+  let unnamedSubsetId = 1;
   return fontFaces.map((fontFace) => {
-    const subset = fontFace.match(/\/\* ([^*]+) \*\//)?.[1];
+    let subset = fontFace.match(/\/\* ([^*]+) \*\//)?.[1];
     let family = fontFace.match(/font-family: '([^']+)'/)?.[1];
     const style = fontFace.match(/font-style: ([^;]+);/)?.[1];
     const weight = fontFace.match(/font-weight: ([^;]+);/)?.[1];
@@ -125,7 +126,12 @@ function extractFontFaces(css: string, name: string): FontFace[] {
     const src = fontFace.match(/src: url\('?([^']+)'?\)/)?.[1];
     const range = fontFace.match(/unicode-range: ([^;]+);/)?.[1];
 
-    if (!family || !style || !weight || !src || !range || !subset) {
+    if (!subset) {
+      subset = `[${unnamedSubsetId}]`;
+      unnamedSubsetId++;
+    }
+
+    if (!family || !style || !weight || !src || !range) {
       throw new Error("Invalid font-face");
     }
 


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

When using Japanese fonts such as Zen Maru Gothic, the Japanese subset is not installed and will not be applied.

Since font-face does not necessarily have a subset name, I modified the regular expression.

e.g. https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic:wght@700&display=swap

reproduction: https://github.com/ras0q/lume-repro-google-fonts-missing-subsets/tree/main/after

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes https://github.com/lumeland/lume/issues/784

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
      - **Q: What kind of test is required?**
  - [x] Run deno `fmt` to fix the code format before commit.
  - [j] Document any change in the `CHANGELOG.md`.
