### PR TITLE
fix serveFile path normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Go to the `v1` branch to see the changelog of Lume 1.
 ### Added
 - Plugin `icons`: added [Ionicons catalog](https://ionic.io/ionicons)
 
+### Fixed
+- Ensure url pathname is normalized in `serveFile`
+
 ## [3.1.0] - 2025-10-17
 ### Added
 - New plugin `validate_html`.

--- a/core/server.ts
+++ b/core/server.ts
@@ -147,7 +147,7 @@ export async function serveFile(
   request: Request,
 ): Promise<Response> {
   const url = new URL(request.url);
-  const pathname = decodeURIComponentSafe(url.pathname);
+  const pathname = posix.normalize(decodeURIComponentSafe(url.pathname));
   const path = posix.join(root, pathname);
 
   try {

--- a/tests/assets/no.txt
+++ b/tests/assets/no.txt
@@ -1,0 +1,1 @@
+This file should never be served.

--- a/tests/static_files.test.ts
+++ b/tests/static_files.test.ts
@@ -1,4 +1,5 @@
-import { assertSiteSnapshot, build, getSite } from "./utils.ts";
+import { assertSiteSnapshot, build, getSite, runRequest } from "./utils.ts";
+import { assertEquals } from "../deps/assert.ts";
 
 Deno.test("Copy static files", async (t) => {
   const site = getSite({
@@ -32,4 +33,20 @@ Deno.test("Copy static files", async (t) => {
 
   await build(site);
   await assertSiteSnapshot(t, site);
+});
+
+Deno.test("Ensure file doesn't resolve outside root", async () => {
+  const site = getSite({
+    src: "static_files",
+  });
+
+  const server = site.getServer();
+
+  const response = await runRequest(
+    server,
+    new Request("http://localhost/..%2fno.txt"),
+  );
+
+  await response.body?.cancel();
+  assertEquals(response.status, 404);
 });


### PR DESCRIPTION
## Description

Ensure that the url pathname is normalized before serving it. 

## Related Issues

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
