### PR TITLE
fix: build failing on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
   - The `src` storage can be overwriten in the `_cms.ts` file.
 - Pages defined with `site.page({ url: "foo", content: (data) => "..." })` uses automatically `js` as the template engine.
 - The `server.root` option is always relative to the dest folder.
+- Fix esbuild plugin resolution erroring with Windows style file paths.
 
 ### Removed
 - `LUME_PROXIED` environment variable is no longer needed.

--- a/plugins/esbuild.ts
+++ b/plugins/esbuild.ts
@@ -209,7 +209,12 @@ export function esbuild(userOptions?: Options) {
                 ? ResolutionMode.Require
                 : ResolutionMode.Import;
 
-              const res = await loader.resolve(path, importer, mode);
+              // Ensure that we're dealing with a specifier, not a standard
+              // file path. This is needed for Windows paths.
+              const specifier = /^\w:[\\/]/i.test(path)
+                ? toFileUrl(path).href
+                : path;
+              const res = await loader.resolve(specifier, importer, mode);
 
               let namespace: string | undefined;
               if (res.startsWith("file:")) {


### PR DESCRIPTION
## Description

This PR fixes lume builds crashing for `denoland/docs` under windows.

The `@deno/loader` plugin expects a specifier, not a file path. This accidentally worked on UNIX systems, but not on windows where file paths are different.


## Related Issues

N/A

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
