### PR TITLE
fix: use decodeURIComponentSafe instead of decodeURI

### DIFF
--- a/core/utils/page_url.ts
+++ b/core/utils/page_url.ts
@@ -1,5 +1,5 @@
 import { posix } from "../../deps/path.ts";
-import { getExtension, normalizePath } from "./path.ts";
+import { decodeURIComponentSafe, getExtension, normalizePath } from "./path.ts";
 
 import type { Destination } from "../source.ts";
 import type { Data, Page, RawData } from "../file.ts";
@@ -18,10 +18,10 @@ export function getBasename(url: string): string {
   }
 
   if (url.endsWith("/")) {
-    return decodeURI(posix.basename(url));
+    return decodeURIComponentSafe(posix.basename(url));
   }
 
-  return decodeURI(posix.basename(url, getExtension(url)));
+  return decodeURIComponentSafe(posix.basename(url, getExtension(url)));
 }
 
 /** Returns the final URL assigned to a page */
@@ -103,7 +103,7 @@ function getDefaultUrl(
 
 /** Remove the /index.html part if exist and replace spaces */
 function normalizeUrl(url: string): string {
-  url = encodeURI(url);
+  url = encodeURIComponent(url);
 
   if (url.endsWith("/index.html")) {
     return url.slice(0, -10);

--- a/core/utils/path.ts
+++ b/core/utils/path.ts
@@ -104,6 +104,7 @@ export function resolveInclude(
 
 /**
  * decodeURI() can't decode the `%` character, as it is used in any encoded character
+ * @author [Why does decodeURIComponent('%') lock up my browser?](https://stackoverflow.com/a/54310080/3416774)
  */
 export function decodeURIComponentSafe(path: string): string {
   return decodeURIComponent(path.replace(/%(?![0-9a-fA-F]+)/g, "%25"));


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [ ] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [ ] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [ ] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
- [ ] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
