### PR TITLE
Support for `.mjs` as the extension of _component scripts' output file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 - `parseBasename` functions accept a second argument with the parent data object, useful for aggregated values. For example to parse the full date in `/posts/2024/06/21/hello-world.md`.
 - `relativeUrls` plugin: add `relativeUrl` filter.
 - Support for `.xhtml` pages (required to build ebooks).
+- Support for `.mjs` as the extension of _component scripts' output file.
 
 ### Changed
 - `date` plugin: if no language is specified to the filter, use the current page language. If it's not defined, use the default language.

--- a/core/site.ts
+++ b/core/site.ts
@@ -899,11 +899,11 @@ export default class Site {
         continue;
       }
 
-      if (path.endsWith(".js")) {
+      if (path.endsWith(".js") || path.endsWith(".mjs")) {
         this.debugBar?.startMeasure("components-js");
         // https://github.com/lumeland/lume/issues/659
         const existingFile = this.search.file(
-          path.replace(/.js$/, "{.js,.ts}"),
+          path.replace(/.m?js$/, "{.mjs,.js,.ts}"),
         );
         const page = await this.getOrCreatePage(existingFile || path);
         page.text = insertContent(

--- a/tests/__snapshots__/components.test.ts.snap
+++ b/tests/__snapshots__/components.test.ts.snap
@@ -716,3 +716,231 @@ snapshot[`Components with esbuild 3`] = `
   },
 ]
 `;
+
+snapshot[`Components with .mjs script output 1`] = `
+{
+  formats: [
+    {
+      engines: 0,
+      ext: ".page.toml",
+      isPage: true,
+      loader: [AsyncFunction: toml],
+    },
+    {
+      engines: 1,
+      ext: ".page.ts",
+      isPage: true,
+      loader: [AsyncFunction: module],
+    },
+    {
+      engines: 1,
+      ext: ".page.js",
+      isPage: true,
+      loader: [AsyncFunction: module],
+    },
+    {
+      engines: 0,
+      ext: ".page.jsonc",
+      isPage: true,
+      loader: [AsyncFunction: json],
+    },
+    {
+      engines: 0,
+      ext: ".page.json",
+      isPage: true,
+      loader: [AsyncFunction: json],
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: 0,
+      ext: ".json",
+      loader: [AsyncFunction: json],
+    },
+    {
+      dataLoader: [AsyncFunction: json],
+      engines: 0,
+      ext: ".jsonc",
+      loader: [AsyncFunction: json],
+    },
+    {
+      engines: 1,
+      ext: ".md",
+      isPage: true,
+      loader: [AsyncFunction: text],
+    },
+    {
+      engines: 1,
+      ext: ".markdown",
+      isPage: true,
+      loader: [AsyncFunction: text],
+    },
+    {
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".js",
+      loader: [AsyncFunction: module],
+    },
+    {
+      dataLoader: [AsyncFunction: module],
+      engines: 1,
+      ext: ".ts",
+      loader: [AsyncFunction: module],
+    },
+    {
+      engines: 1,
+      ext: ".vento",
+      isPage: true,
+      loader: [AsyncFunction: text],
+    },
+    {
+      engines: 1,
+      ext: ".vto",
+      isPage: true,
+      loader: [AsyncFunction: text],
+    },
+    {
+      dataLoader: [AsyncFunction: toml],
+      engines: 0,
+      ext: ".toml",
+      loader: [AsyncFunction: toml],
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: 0,
+      ext: ".yaml",
+      isPage: true,
+      loader: [AsyncFunction: yaml],
+    },
+    {
+      dataLoader: [AsyncFunction: yaml],
+      engines: 0,
+      ext: ".yml",
+      isPage: true,
+      loader: [AsyncFunction: yaml],
+    },
+  ],
+  src: [
+    "/",
+    "/_components",
+    "/_components/eta_button.eta",
+    "/_components/header",
+    "/_components/header/comp.vto",
+    "/_components/header/script.js",
+    "/_components/header/style.css",
+    "/_components/inherit.njk",
+    "/_components/jsx_button.jsx",
+    "/_components/njk_button.njk",
+    "/_components/not_inherit.njk",
+    "/_components/vento_button.vto",
+    "/_data.yml",
+    "/index.vto",
+    "/script.ts",
+    "/subfolder",
+    "/subfolder/_components",
+    "/subfolder/_components/innerButton.js",
+    "/subfolder/_components/pug_button.pug",
+    "/subfolder/_components/ts_button.ts",
+    "/subfolder/index.njk",
+  ],
+}
+`;
+
+snapshot[`Components with .mjs script output 2`] = `[]`;
+
+snapshot[`Components with .mjs script output 3`] = `
+[
+  {
+    content: 'index
+
+<header id="header" class="header">
+  <h1>Hello world</h1>
+</header>
+
+<header id="header" class="header">
+  <h1>foo</h1>
+</header>
+',
+    data: {
+      basename: "",
+      children: 'index
+
+<header id="header" class="header">
+  <h1>Hello world</h1>
+</header>
+
+<header id="header" class="header">
+  <h1>foo</h1>
+</header>
+',
+      comp: [
+        "_components",
+        "_proxies",
+      ],
+      content: 'index
+
+{{ comp header { title: "Hello world" } /}}
+{{ comp header /}}',
+      date: [],
+      mergedKeys: [
+        "tags",
+      ],
+      page: [
+        "src",
+        "data",
+        "isCopy",
+      ],
+      paginate: "paginate",
+      search: [],
+      tags: "Array(0)",
+      text: "Hello from _data.yml",
+      url: "/",
+    },
+    src: {
+      ext: ".vto",
+      path: "/index",
+      remote: undefined,
+    },
+  },
+  {
+    content: '// fs:/_components/header/script.js
+document.getElementById("header")?.addEventListener("click", function() {
+  alert("Header clicked");
+});
+',
+    data: {
+      basename: "script",
+      page: [
+        "src",
+        "data",
+        "isCopy",
+      ],
+      url: "/script.mjs",
+    },
+    src: {
+      ext: "",
+      path: "",
+      remote: undefined,
+    },
+  },
+  {
+    content: ".header {
+  background-color: pink;
+}
+",
+    data: {
+      basename: "style",
+      page: [
+        "src",
+        "data",
+        "isCopy",
+      ],
+      url: "/style.css",
+    },
+    src: {
+      ext: "",
+      path: "",
+      remote: undefined,
+    },
+  },
+]
+`;

--- a/tests/components.test.ts
+++ b/tests/components.test.ts
@@ -200,3 +200,17 @@ Deno.test(
     await assertSiteSnapshot(t, site);
   },
 );
+
+Deno.test(
+  "Components with .mjs script output",
+  { sanitizeOps: false, sanitizeResources: false },
+  async (t) => {
+    const site = getSite({
+      src: "components",
+      jsFile: "script.mjs",
+    });
+
+    await build(site);
+    await assertSiteSnapshot(t, site);
+  },
+);


### PR DESCRIPTION
## Description

The use of `.mjs` file extension for module scripts doesn't matter, but it is recommended by [V8 documentation](https://v8.dev/features/modules#mjs) for clarity.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
