### PR TITLE
Fix reload middleware decoding multi-byte UTF-8 across chunk boundaries

### DIFF
--- a/middlewares/reload.ts
+++ b/middlewares/reload.ts
@@ -112,10 +112,14 @@ export function reload(options: Options): Middleware {
     let result = await reader.read();
     const decoder = new TextDecoder();
 
+    // Use streaming mode so multi-byte UTF-8 sequences that straddle chunk
+    // boundaries are decoded correctly instead of being replaced with U+FFFD.
     while (!result.done) {
-      body += decoder.decode(result.value);
+      body += decoder.decode(result.value, { stream: true });
       result = await reader.read();
     }
+    // Flush any remaining state from the decoder.
+    body += decoder.decode();
 
     let source = `${reloadClient};
     liveReload(${revision}, "${options.basepath}", ${response.status}, "${

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -1,19 +1,24 @@
 import { assert, assertEquals } from "../deps/assert.ts";
 import { reload } from "../middlewares/reload.ts";
-import type { Watcher } from "../core/watcher.ts";
+import type { Watcher, WatchEvent, WatchEventType } from "../core/watcher.ts";
+import type { EventListener, EventOptions } from "../core/events.ts";
 
 // Minimal Watcher stub. The reload middleware only calls `addEventListener`
-// and `start` during construction, so we return a no-op implementation.
-function mockWatcher(): Watcher {
-  return {
-    addEventListener() {
-      return this;
-    },
-    async dispatchEvent() {
-      return true;
-    },
-    async start() {},
-  } as Watcher;
+// and `start` during construction, so these are no-op implementations.
+class MockWatcher implements Watcher {
+  addEventListener(
+    _type: WatchEventType,
+    _listener: EventListener<WatchEvent>,
+    _options?: EventOptions,
+  ): this {
+    return this;
+  }
+  dispatchEvent(_event: WatchEvent): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 Deno.test(
@@ -43,22 +48,14 @@ Deno.test(
       headers: { "content-type": "text/html; charset=utf-8" },
     });
 
-    // Silence the middleware's console.log during watcher.start().
-    const originalLog = console.log;
-    console.log = () => {};
-    let middleware;
-    try {
-      middleware = reload({
-        watcher: mockWatcher(),
-        basepath: "/",
-      });
-    } finally {
-      console.log = originalLog;
-    }
+    const middleware = reload({
+      watcher: new MockWatcher(),
+      basepath: "/",
+    });
 
     const response = await middleware(
       new Request("http://localhost/"),
-      async () => upstream,
+      () => Promise.resolve(upstream),
       {} as Deno.ServeHandlerInfo,
     );
 

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -1,0 +1,78 @@
+import { assert, assertEquals } from "../deps/assert.ts";
+import { reload } from "../middlewares/reload.ts";
+import type { Watcher } from "../core/watcher.ts";
+
+// Minimal Watcher stub. The reload middleware only calls `addEventListener`
+// and `start` during construction, so we return a no-op implementation.
+function mockWatcher(): Watcher {
+  return {
+    addEventListener() {
+      return this;
+    },
+    async dispatchEvent() {
+      return true;
+    },
+    async start() {},
+  } as Watcher;
+}
+
+Deno.test(
+  "reload middleware preserves multi-byte UTF-8 chars across chunk boundaries",
+  async () => {
+    // "メモリ帯域" where "モ" is 0xE3 0x83 0xA2 in UTF-8.
+    // Split the bytes so the chunk boundary falls in the middle of "モ",
+    // which used to corrupt the character into U+FFFD replacements.
+    const html = "<html><body>メモリ帯域</body></html>";
+    const moIndex = html.indexOf("モ");
+    const prefix = new TextEncoder().encode(html.slice(0, moIndex));
+    const moBytes = new TextEncoder().encode("モ"); // 3 bytes
+    const suffix = new TextEncoder().encode(html.slice(moIndex + 1));
+    const chunk1 = new Uint8Array([...prefix, moBytes[0], moBytes[1]]);
+    const chunk2 = new Uint8Array([moBytes[2], ...suffix]);
+
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(chunk1);
+        controller.enqueue(chunk2);
+        controller.close();
+      },
+    });
+
+    const upstream = new Response(body, {
+      status: 200,
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+
+    // Silence the middleware's console.log during watcher.start().
+    const originalLog = console.log;
+    console.log = () => {};
+    let middleware;
+    try {
+      middleware = reload({
+        watcher: mockWatcher(),
+        basepath: "/",
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    const response = await middleware(
+      new Request("http://localhost/"),
+      async () => upstream,
+      {} as Deno.ServeHandlerInfo,
+    );
+
+    const decoded = await response.text();
+    // The original HTML content must survive intact.
+    assert(
+      decoded.includes("メモリ帯域"),
+      `expected "メモリ帯域" to be preserved, got: ${decoded}`,
+    );
+    // And no UTF-8 replacement characters (U+FFFD) should appear.
+    assertEquals(
+      decoded.includes("\uFFFD"),
+      false,
+      "response must not contain U+FFFD replacement characters",
+    );
+  },
+);


### PR DESCRIPTION
## Description

The live-reload middleware reads the upstream HTML body in chunks and decodes each chunk with `TextDecoder.decode(value)` without `{ stream: true }`. When a chunk boundary falls inside a multi-byte UTF-8 sequence, the partial bytes at the end of the chunk get replaced with U+FFFD, corrupting the served HTML.

This PR switches the decode loop to streaming mode and flushes the decoder after the last chunk, and adds a regression test that feeds a body whose chunks split a 3-byte Japanese character.

The on-disk `_site/` output was never affected — only the dev server's response path.

### Before (at a chunk boundary on `モ` = `0xE3 0x83 0xA2`)

```
served bytes: ... メ EF BF BD EF BF BD EF BF BD リ 帯 域 ...
served text : ... メ ��� リ帯域 ...
```

### After

```
served bytes: ... メ E3 83 A2 リ 帯 域 ...
served text : ... メモリ帯域 ...
```

### Regression test

`tests/reload.test.ts` sends a `ReadableStream` whose two chunks split `モ` as `[E3 83] [A2]`, wraps it in a `Response`, pipes it through the `reload` middleware, and asserts that the output contains `メモリ帯域` and no U+FFFD.

Confirmed:
- test fails on `main` (old decode without `{ stream: true }`)
- test passes with the fix

## Related Issues

Fixes #835

### Check List

- [x] Have you read the [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature.
  - [x] Write tests.
  - [x] Run `deno fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`. — I have deliberately left `CHANGELOG.md` untouched to avoid conflicts with other PRs targeting the `3.2.5 - Unreleased` section. Happy to add an entry (with this PR number) once the change is accepted, or leave it to the maintainer.

### AI code disclosure

Per the "AI code" section of CONTRIBUTING: the fix, tests, and this PR description were drafted with Claude Code assistance. The diagnosis started from a reproducible bug on my site (multi-byte characters serving as U+FFFD only through `lume -s`, never in the on-disk output), and the minimal fix (adding `{ stream: true }` + final flush) was verified by the added test. All changes were reviewed and committed by me.