### PR TITLE
Various improvements for `robots` plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Go to the `v2` branch to see the changelog of Lume 2.
 Go to the `v1` branch to see the changelog of Lume 1.
 
 ## [3.2.5] - Unreleased
+### Added
+- `robots` plugin: support rule grouping
+- `robots` plugin: support Content-Signal rule
+
+### Changed
+- `robots` and `sitemap` plugins: the generated `robots.txt` content will always end with a newline
+
 ### Fixed
 - Don't break the build if a loader throws an error.
 - `google_fonts` plugin ignores display parameter [#834]

--- a/plugins/robots.ts
+++ b/plugins/robots.ts
@@ -19,6 +19,8 @@ type Rule = {
   sitemap?: string;
   /** Clean-param */
   cleanParam?: string;
+  /** Content-signal */
+  contentSignal?: string;
 };
 
 const ruleSort = [

--- a/plugins/robots.ts
+++ b/plugins/robots.ts
@@ -101,7 +101,8 @@ export function robots(userOptions?: Partial<Options>) {
               }: ${value}`
             )
             .join("\n")
-        ).join("\n\n");
+        ).join("\n\n") +
+        "\n";
     });
   };
 }

--- a/plugins/robots.ts
+++ b/plugins/robots.ts
@@ -4,19 +4,19 @@ import type Site from "../core/site.ts";
 
 type Rule = {
   /** User-agent */
-  userAgent?: string;
+  userAgent?: string[] | string;
   /** Crawl-delay */
   crawlDelay?: string;
   /** Disallow */
-  disallow?: string;
+  disallow?: string[] | string;
   /** Disavow */
   disavow?: string;
   /** Allow */
-  allow?: string;
+  allow?: string[] | string;
   /** Host */
   host?: string;
   /** Sitemap */
-  sitemap?: string;
+  sitemap?: string[] | string;
   /** Clean-param */
   cleanParam?: string;
   /** Content-signal */
@@ -71,19 +71,13 @@ export function robots(userOptions?: Partial<Options>) {
         ? [options.disallow]
         : options.disallow;
 
-      allow?.forEach((userAgent) =>
-        rules.push({
-          userAgent,
-          allow: "/",
-        })
-      );
+      if (allow && allow.length > 0) {
+        rules.push({ userAgent: allow, allow: "/" });
+      }
 
-      disallow?.forEach((userAgent) =>
-        rules.push({
-          userAgent,
-          disallow: "/",
-        })
-      );
+      if (disallow && disallow.length > 0) {
+        rules.push({ userAgent: disallow, disallow: "/" });
+      }
 
       rules.push(...(options.rules ?? []));
 
@@ -98,11 +92,12 @@ export function robots(userOptions?: Partial<Options>) {
               ruleSort.indexOf(keyA) - ruleSort.indexOf(keyB)
             )
             .map(([key, value]) =>
-              `${key.charAt(0).toUpperCase()}${
-                key.slice(1).replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase()
-              }: ${value}`
-            )
-            .join("\n")
+              (typeof value === "string" ? [value] : value).map((item) =>
+                `${key.charAt(0).toUpperCase()}${
+                  key.slice(1).replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase()
+                }: ${item}`
+              ).join("\n")
+            ).join("\n")
         ).join("\n\n") +
         "\n";
     });

--- a/plugins/sitemap.ts
+++ b/plugins/sitemap.ts
@@ -80,7 +80,7 @@ export function sitemap(userOptions?: Options) {
       const robots = await site.getOrCreatePage("/robots.txt");
       robots.text = `${robots.text}\nSitemap: ${
         site.url(options.filename, true)
-      }`;
+      }\n`;
     });
 
     function generateSitemap(pages: Data[]): string {

--- a/tests/__snapshots__/robots.test.ts.snap
+++ b/tests/__snapshots__/robots.test.ts.snap
@@ -461,7 +461,8 @@ snapshot[`Robots plugin 3`] = `
   },
   {
     content: "User-agent: *
-Allow: /",
+Allow: /
+",
     data: {
       basename: "robots",
       page: [
@@ -941,10 +942,9 @@ snapshot[`Robots plugin with allow 3`] = `
   },
   {
     content: "User-agent: Googlebot
-Allow: /
-
 User-agent: Bingbot
-Allow: /",
+Allow: /
+",
     data: {
       basename: "robots",
       page: [
@@ -1427,7 +1427,8 @@ snapshot[`Robots plugin with disallow 3`] = `
 Allow: /
 
 User-agent: ChatGPT-User
-Disallow: /",
+Disallow: /
+",
     data: {
       basename: "robots",
       page: [
@@ -1912,7 +1913,13 @@ Allow: /
 User-agent: *
 Disallow: /admin
 
-Sitemap: https://example.com/sitemap.xml",
+User-agent: MistralAI-User
+User-agent: ChatGPT-User
+Disallow: /img
+Disallow: /assets
+
+Sitemap: https://example.com/sitemap.xml
+",
     data: {
       basename: "robots",
       page: [

--- a/tests/__snapshots__/sitemap.test.ts.snap
+++ b/tests/__snapshots__/sitemap.test.ts.snap
@@ -461,7 +461,8 @@ snapshot[`Sitemap plugin 3`] = `
   },
   {
     content: "
-Sitemap: https://example.com/sitemap.xml",
+Sitemap: https://example.com/sitemap.xml
+",
     data: {
       basename: "robots",
       page: [
@@ -1248,7 +1249,8 @@ snapshot[`Sitemap plugin with a multilanguage plugin 3`] = `
   },
   {
     content: "
-Sitemap: https://example.com/sitemap.xml",
+Sitemap: https://example.com/sitemap.xml
+",
     data: {
       basename: "robots",
       page: [
@@ -1956,7 +1958,8 @@ snapshot[`Sitemap plugin with filter_pages plugin 3`] = `
   },
   {
     content: "
-Sitemap: https://example.com/sitemap.xml",
+Sitemap: https://example.com/sitemap.xml
+",
     data: {
       basename: "robots",
       page: [
@@ -2341,7 +2344,8 @@ snapshot[`Sitemap plugin with redirects plugin 3`] = `
   },
   {
     content: "
-Sitemap: https://example.com/sitemap.xml",
+Sitemap: https://example.com/sitemap.xml
+",
     data: {
       basename: "robots",
       page: [

--- a/tests/robots.test.ts
+++ b/tests/robots.test.ts
@@ -61,6 +61,10 @@ Deno.test("Robots plugin with custom rules", async (t) => {
         disallow: "/admin",
       },
       {
+        userAgent: ["MistralAI-User", "ChatGPT-User"],
+        disallow: ["/img", "/assets"],
+      },
+      {
         sitemap: new URL("/sitemap.xml", site.options.location).href,
       },
     ],


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

The main reason behind ending `robots.txt` file with a newline is for the case when `sitemap` and `robots` plugins are used together. The sitemap rule, then, will be properly appended into its own group.

I'm only aware of `allow`, `disallow`, `sitemap` and `user-agent` rules, according to https://developers.google.com/crawling/docs/robots-txt/robots-txt-spec#syntax, so rule grouping is only enabled for those directives.

Please see individual commits for related changes!

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [ ] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
