### PR TITLE
Suggestion: downloader plugin

### DIFF
--- a/plugins/downloader.ts
+++ b/plugins/downloader.ts
@@ -1,10 +1,10 @@
-import type Site from "lume/core/site.ts";
+import type Site from "../core/site.ts";
 
-import { merge } from "lume/core/utils/object.ts";
-import { isUrl } from "lume/core/utils/path.ts";
-import { read } from "lume/core/utils/read.ts";
-import { posix } from "lume/deps/path.ts";
-import modifyUrls from "lume/plugins/modify_urls.ts";
+import { merge } from "../core/utils/object.ts";
+import { isUrl } from "../core/utils/path.ts";
+import { read } from "../core/utils/read.ts";
+import { posix } from "../deps/path.ts";
+import modifyUrls from "../plugins/modify_urls.ts";
 
 export interface Options {
   /** Domains to download images from */

--- a/plugins/downloader.ts
+++ b/plugins/downloader.ts
@@ -1,0 +1,81 @@
+import type Site from "lume/core/site.ts";
+
+import { merge } from "lume/core/utils/object.ts";
+import { isUrl } from "lume/core/utils/path.ts";
+import { read } from "lume/core/utils/read.ts";
+import { posix } from "lume/deps/path.ts";
+import modifyUrls from "lume/plugins/modify_urls.ts";
+
+export interface Options {
+	/** Domains to download images from */
+	origins: string[];
+
+	/** The folder where the images will be saved */
+	folder: string;
+
+	/** CSS selector the element needs to match */
+	selector: string;
+}
+
+export const defaults: Options = {
+	origins: [],
+	folder: "/_assets",
+	selector: "img,source,use",
+};
+
+export function downloader(userOptions?: Partial<Options>) {
+	const options = merge(defaults, userOptions);
+
+	return (site: Site) => {
+		site.use(modifyUrls({ fn: download }));
+
+		async function download(path: string, _page: Lume.Page, element?: Element) {
+			const [pathAndQuery, frag] = path.split("#", 2);
+
+			if (!pathAndQuery) {
+				return path;
+			}
+
+			const fileIndex = site.files.findIndex((file) => file.data.url === pathAndQuery);
+			const file = site.files[fileIndex];
+
+			let url, content;
+
+			if (file) {
+				if (!file.src.entry.flags.has("remote")) {
+					return path;
+				}
+
+				site.files.splice(fileIndex, 1);
+
+				path = file.src.entry.src;
+				content = await read(path, true);
+				url = file.data.url;
+			} else {
+				if (
+					!isUrl(path) ||
+					!options.origins.includes(new URL(path).host) ||
+					(element && !element.matches(options.selector))
+				) {
+					return path;
+				}
+
+				const res = await fetch(pathAndQuery);
+				content = await res.arrayBuffer();
+				content = new Uint8Array(content);
+				const filename = posix.basename(pathAndQuery);
+				const hash = await crypto.subtle.digest("SHA-1", content);
+				const hashHex = new Uint8Array(hash).toHex();
+				url = posix.join(options.folder, `${hashHex}-${filename}`);
+			}
+
+			const page = await site.getOrCreatePage(url);
+			page.content = content;
+			page.src.ext = posix.extname(path);
+
+			return frag ? `${url}#${frag}` : url;
+		}
+	};
+}
+
+export default downloader;

--- a/plugins/downloader.ts
+++ b/plugins/downloader.ts
@@ -17,7 +17,7 @@ export interface Options {
   selector: string;
 
   /** Attribute to use as selector. Unlike with `selector`, it's possible to assign the attribute a value to manually define a target file name. */
-  attribute?: string;
+  attribute: string;
 }
 
 export const defaults: Options = {
@@ -40,7 +40,7 @@ export function downloader(userOptions?: Partial<Options>) {
         !isUrl(path) ||
         !pathAndQuery ||
         !options.origins.includes(new URL(path).host) ||
-        (element && !element.matches(options.selector))
+        (element && options.selector && !element.matches(options.selector))
       ) {
         return path;
       }

--- a/plugins/downloader.ts
+++ b/plugins/downloader.ts
@@ -15,12 +15,16 @@ export interface Options {
 
   /** CSS selector the element needs to match */
   selector: string;
+
+  /** Attribute to use as selector. Unlike with `selector`, it's possible to assign the attribute a value to manually define a target file name. */
+  attribute?: string;
 }
 
 export const defaults: Options = {
   origins: [],
   folder: "/_assets",
   selector: "img,source,use",
+  attribute: "",
 };
 
 export function downloader(userOptions?: Partial<Options>) {
@@ -30,27 +34,35 @@ export function downloader(userOptions?: Partial<Options>) {
     site.use(modifyUrls({ fn: download }));
 
     async function download(path: string, _page: Lume.Page, element?: Element) {
+      const [pathAndQuery, frag] = path.split("#", 2);
+
       if (
         !isUrl(path) ||
+        !pathAndQuery ||
         !options.origins.includes(new URL(path).host) ||
         (element && !element.matches(options.selector))
       ) {
         return path;
       }
 
-      const [pathAndQuery, frag] = path.split("#", 2);
+      let url;
 
-      if (!pathAndQuery) {
-        return path;
+      if (options.attribute) {
+        if (element && !element.matches(`[${options.attribute}]`)) {
+          return path;
+        }
+
+        url = element?.getAttribute(options.attribute);
       }
 
       const content = await read(pathAndQuery, true);
-      const filename = posix.basename(pathAndQuery);
-      const hash = await crypto.subtle.digest("SHA-1", content);
-      const hashHex = new Uint8Array(hash).toHex();
-      const url = posix.join(options.folder, `${hashHex}-${filename}`);
 
-      // site.remoteFile(url, pathAndQuery);
+      if (!url) {
+        const filename = posix.basename(pathAndQuery);
+        const hash = await crypto.subtle.digest("SHA-1", content);
+        const hashHex = new Uint8Array(hash).toHex();
+        url = posix.join(options.folder, `${hashHex}-${filename}`);
+      }
 
       const page = await site.getOrCreatePage(url);
       page.content = content;

--- a/plugins/downloader.ts
+++ b/plugins/downloader.ts
@@ -7,75 +7,77 @@ import { posix } from "lume/deps/path.ts";
 import modifyUrls from "lume/plugins/modify_urls.ts";
 
 export interface Options {
-	/** Domains to download images from */
-	origins: string[];
+  /** Domains to download images from */
+  origins: string[];
 
-	/** The folder where the images will be saved */
-	folder: string;
+  /** The folder where the images will be saved */
+  folder: string;
 
-	/** CSS selector the element needs to match */
-	selector: string;
+  /** CSS selector the element needs to match */
+  selector: string;
 }
 
 export const defaults: Options = {
-	origins: [],
-	folder: "/_assets",
-	selector: "img,source,use",
+  origins: [],
+  folder: "/_assets",
+  selector: "img,source,use",
 };
 
 export function downloader(userOptions?: Partial<Options>) {
-	const options = merge(defaults, userOptions);
+  const options = merge(defaults, userOptions);
 
-	return (site: Site) => {
-		site.use(modifyUrls({ fn: download }));
+  return (site: Site) => {
+    site.use(modifyUrls({ fn: download }));
 
-		async function download(path: string, _page: Lume.Page, element?: Element) {
-			const [pathAndQuery, frag] = path.split("#", 2);
+    async function download(path: string, _page: Lume.Page, element?: Element) {
+      const [pathAndQuery, frag] = path.split("#", 2);
 
-			if (!pathAndQuery) {
-				return path;
-			}
+      if (!pathAndQuery) {
+        return path;
+      }
 
-			const fileIndex = site.files.findIndex((file) => file.data.url === pathAndQuery);
-			const file = site.files[fileIndex];
+      const fileIndex = site.files.findIndex((file) =>
+        file.data.url === pathAndQuery
+      );
+      const file = site.files[fileIndex];
 
-			let url, content;
+      let url, content;
 
-			if (file) {
-				if (!file.src.entry.flags.has("remote")) {
-					return path;
-				}
+      if (file) {
+        if (!file.src.entry.flags.has("remote")) {
+          return path;
+        }
 
-				site.files.splice(fileIndex, 1);
+        site.files.splice(fileIndex, 1);
 
-				path = file.src.entry.src;
-				content = await read(path, true);
-				url = file.data.url;
-			} else {
-				if (
-					!isUrl(path) ||
-					!options.origins.includes(new URL(path).host) ||
-					(element && !element.matches(options.selector))
-				) {
-					return path;
-				}
+        path = file.src.entry.src;
+        content = await read(path, true);
+        url = file.data.url;
+      } else {
+        if (
+          !isUrl(path) ||
+          !options.origins.includes(new URL(path).host) ||
+          (element && !element.matches(options.selector))
+        ) {
+          return path;
+        }
 
-				const res = await fetch(pathAndQuery);
-				content = await res.arrayBuffer();
-				content = new Uint8Array(content);
-				const filename = posix.basename(pathAndQuery);
-				const hash = await crypto.subtle.digest("SHA-1", content);
-				const hashHex = new Uint8Array(hash).toHex();
-				url = posix.join(options.folder, `${hashHex}-${filename}`);
-			}
+        const res = await fetch(pathAndQuery);
+        content = await res.arrayBuffer();
+        content = new Uint8Array(content);
+        const filename = posix.basename(pathAndQuery);
+        const hash = await crypto.subtle.digest("SHA-1", content);
+        const hashHex = new Uint8Array(hash).toHex();
+        url = posix.join(options.folder, `${hashHex}-${filename}`);
+      }
 
-			const page = await site.getOrCreatePage(url);
-			page.content = content;
-			page.src.ext = posix.extname(path);
+      const page = await site.getOrCreatePage(url);
+      page.content = content;
+      page.src.ext = posix.extname(path);
 
-			return frag ? `${url}#${frag}` : url;
-		}
-	};
+      return frag ? `${url}#${frag}` : url;
+    }
+  };
 }
 
 export default downloader;

--- a/plugins/downloader.ts
+++ b/plugins/downloader.ts
@@ -44,7 +44,7 @@ export function downloader(userOptions?: Partial<Options>) {
         return path;
       }
 
-      const content = await read(path, true);
+      const content = await read(pathAndQuery, true);
       const filename = posix.basename(pathAndQuery);
       const hash = await crypto.subtle.digest("SHA-1", content);
       const hashHex = new Uint8Array(hash).toHex();

--- a/plugins/downloader.ts
+++ b/plugins/downloader.ts
@@ -30,46 +30,27 @@ export function downloader(userOptions?: Partial<Options>) {
     site.use(modifyUrls({ fn: download }));
 
     async function download(path: string, _page: Lume.Page, element?: Element) {
+      if (
+        !isUrl(path) ||
+        !options.origins.includes(new URL(path).host) ||
+        (element && !element.matches(options.selector))
+      ) {
+        return path;
+      }
+
       const [pathAndQuery, frag] = path.split("#", 2);
 
       if (!pathAndQuery) {
         return path;
       }
 
-      const fileIndex = site.files.findIndex((file) =>
-        file.data.url === pathAndQuery
-      );
-      const file = site.files[fileIndex];
+      const content = await read(path, true);
+      const filename = posix.basename(pathAndQuery);
+      const hash = await crypto.subtle.digest("SHA-1", content);
+      const hashHex = new Uint8Array(hash).toHex();
+      const url = posix.join(options.folder, `${hashHex}-${filename}`);
 
-      let url, content;
-
-      if (file) {
-        if (!file.src.entry.flags.has("remote")) {
-          return path;
-        }
-
-        site.files.splice(fileIndex, 1);
-
-        path = file.src.entry.src;
-        content = await read(path, true);
-        url = file.data.url;
-      } else {
-        if (
-          !isUrl(path) ||
-          !options.origins.includes(new URL(path).host) ||
-          (element && !element.matches(options.selector))
-        ) {
-          return path;
-        }
-
-        const res = await fetch(pathAndQuery);
-        content = await res.arrayBuffer();
-        content = new Uint8Array(content);
-        const filename = posix.basename(pathAndQuery);
-        const hash = await crypto.subtle.digest("SHA-1", content);
-        const hashHex = new Uint8Array(hash).toHex();
-        url = posix.join(options.folder, `${hashHex}-${filename}`);
-      }
+      // site.remoteFile(url, pathAndQuery);
 
       const page = await site.getOrCreatePage(url);
       page.content = content;


### PR DESCRIPTION
## Description

Adds a new `downloader` plugin which downloads resources from allowed domains. This enables the use of remote files in any plugin without having to add explicit support to it, but a possible disadvantage is that these remote files become part of the website bundle even if they only serve as starting point for processing and won't be used in their original form.

I've been using this with my website to allow `image_size` (now obsolete I guess) and `transform_images` to work with image resources hosted on my Strapi instance.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [ ] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
