### PR TITLE
Support tags (categories) in Feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Go to the `v1` branch to see the changelog of Lume 1.
 - `robots` plugin: support Content-Signal rule
 - `feed` plugin: Allow `html` extension for pretty URL [#839]
 - `feed` plugin: New `info.self` option to customize the `self` url [#839]
+- `feed` plugin: Add `items.categories` support, defaults to `"=tags"` [#848]
 - `image_size` plugin: Support for remote files and external URLs.
 - New `LUME_CONCURRENCY` env var to define a custom global concurrency limit [#843].
 - `transform_images` plugin: New `concurrency` option to limit the number of images processed in parallel (10 by default) [#843].

--- a/plugins/feed.ts
+++ b/plugins/feed.ts
@@ -98,6 +98,9 @@ export interface FeedItemOptions {
   /** The item content */
   content?: string | ((data: Data) => string | undefined);
 
+  /** The item categories */
+  categories?: string | ((data: Data) => string[] | undefined);
+
   /** The item language */
   lang?: string | ((data: Data) => string | undefined);
 
@@ -137,6 +140,7 @@ export const defaults: Options = {
     description: "=description",
     published: "=date",
     content: "=children",
+    categories: "=tags",
     lang: "=lang",
   },
 };
@@ -169,6 +173,7 @@ export interface FeedItem {
   published: Date;
   updated?: Date;
   content: string;
+  categories?: string[];
   lang: string;
   image?: string;
   author?: Author;
@@ -241,6 +246,7 @@ export function feed(
               updated: toDate(getDataValue(data, items.updated)),
               content: fixedContent,
               lang: getDataValue(data, items.lang),
+              categories: getDataValue(data, items.categories),
               image,
             };
           }),
@@ -373,6 +379,7 @@ function generateRss(
           },
           description: item.description,
           "content:encoded": cdata(item.content),
+          category: item.categories,
           pubDate: item.published.toUTCString(),
           "atom:updated": item.updated?.toISOString(),
           meta: item.image
@@ -415,6 +422,7 @@ function generateJson(data: FeedData, file: string): string {
       language: item.lang,
       authors: item.author ? [item.author] : undefined,
       content_html: item.content,
+      tags: item.categories,
       date_published: item.published.toISOString(),
       date_modified: item.updated?.toISOString(),
       image: item.image,
@@ -497,6 +505,7 @@ function generateAtom(
             "#text": item.content,
           }
           : undefined,
+        category: item.categories?.map((category) => ({ "@term": category })),
       })),
     },
   };

--- a/plugins/feed.ts
+++ b/plugins/feed.ts
@@ -246,7 +246,7 @@ export function feed(
               updated: toDate(getDataValue(data, items.updated)),
               content: fixedContent,
               lang: getDataValue(data, items.lang),
-              categories: getDataValue(data, items.categories),
+              categories: toStringArray(getDataValue(data, items.categories)),
               image,
             };
           }),
@@ -547,6 +547,14 @@ function clean(obj: Record<string, unknown>): Record<string, unknown> {
       })
       .filter(([, value]) => value !== undefined),
   );
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!value) {
+    return [];
+  }
+  const array = Array.isArray(value) ? value : [value];
+  return array.map((v) => typeof v === 'string' ? v : v.toString());
 }
 
 function toDate(date?: string | number | Date): Date | undefined {

--- a/tests/__snapshots__/feed.test.ts.snap
+++ b/tests/__snapshots__/feed.test.ts.snap
@@ -168,7 +168,7 @@ snapshot[`RSS plugin 3`] = `
       paginate: "paginate",
       published: "1979-06-21T23:45:00.000Z",
       search: [],
-      tags: "Array(0)",
+      tags: "Array(2)",
       title: "Page **5**",
       url: "/page5/",
     },
@@ -208,6 +208,8 @@ snapshot[`RSS plugin 3`] = `
       <uri>https://oscarotero.com</uri>
     </author>
     <content type="html">Content of Page 5</content>
+    <category term="tag1"/>
+    <category term="tag2"/>
   </entry>
 </feed>',
     data: {
@@ -241,6 +243,8 @@ snapshot[`RSS plugin 3`] = `
       <uri>https://oscarotero.com</uri>
     </author>
     <content type="html">Content of Page 5</content>
+    <category term="tag1"/>
+    <category term="tag2"/>
   </entry>
 </feed>',
       page: [
@@ -257,10 +261,10 @@ snapshot[`RSS plugin 3`] = `
     },
   },
   {
-    content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
+    content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","tags":["tag1","tag2"],"date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
     data: {
       basename: "feed",
-      content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
+      content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","tags":["tag1","tag2"],"date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
       page: [
         "src",
         "data",
@@ -301,6 +305,8 @@ snapshot[`RSS plugin 3`] = `
         <uri>https://oscarotero.com</uri>
       </author>
       <content:encoded><![CDATA[Content of Page 5]]></content:encoded>
+      <category>tag1</category>
+      <category>tag2</category>
       <pubDate>Thu, 21 Jun 1979 23:45:00 GMT</pubDate>
       <atom:updated>1979-06-21T23:45:00.000Z</atom:updated>
     </item>
@@ -334,6 +340,8 @@ snapshot[`RSS plugin 3`] = `
         <uri>https://oscarotero.com</uri>
       </author>
       <content:encoded><![CDATA[Content of Page 5]]></content:encoded>
+      <category>tag1</category>
+      <category>tag2</category>
       <pubDate>Thu, 21 Jun 1979 23:45:00 GMT</pubDate>
       <atom:updated>1979-06-21T23:45:00.000Z</atom:updated>
     </item>
@@ -523,7 +531,7 @@ snapshot[`RSS plugin with array function 3`] = `
       paginate: "paginate",
       published: "1979-06-21T23:45:00.000Z",
       search: [],
-      tags: "Array(0)",
+      tags: "Array(2)",
       title: "Page **5**",
       url: "/page5/",
     },
@@ -564,6 +572,8 @@ snapshot[`RSS plugin with array function 3`] = `
       <uri>https://oscarotero.com</uri>
     </author>
     <content type="html">Content of Page 5</content>
+    <category term="tag1"/>
+    <category term="tag2"/>
   </entry>
 </feed>',
     data: {
@@ -598,6 +608,8 @@ snapshot[`RSS plugin with array function 3`] = `
       <uri>https://oscarotero.com</uri>
     </author>
     <content type="html">Content of Page 5</content>
+    <category term="tag1"/>
+    <category term="tag2"/>
   </entry>
 </feed>',
       page: [
@@ -614,10 +626,10 @@ snapshot[`RSS plugin with array function 3`] = `
     },
   },
   {
-    content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed1.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
+    content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed1.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","tags":["tag1","tag2"],"date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
     data: {
       basename: "feed1",
-      content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed1.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
+      content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed1.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","tags":["tag1","tag2"],"date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
       page: [
         "src",
         "data",
@@ -659,6 +671,8 @@ snapshot[`RSS plugin with array function 3`] = `
         <uri>https://oscarotero.com</uri>
       </author>
       <content:encoded><![CDATA[Content of Page 5]]></content:encoded>
+      <category>tag1</category>
+      <category>tag2</category>
       <pubDate>Thu, 21 Jun 1979 23:45:00 GMT</pubDate>
       <atom:updated>1979-06-21T23:45:00.000Z</atom:updated>
     </item>
@@ -693,6 +707,8 @@ snapshot[`RSS plugin with array function 3`] = `
         <uri>https://oscarotero.com</uri>
       </author>
       <content:encoded><![CDATA[Content of Page 5]]></content:encoded>
+      <category>tag1</category>
+      <category>tag2</category>
       <pubDate>Thu, 21 Jun 1979 23:45:00 GMT</pubDate>
       <atom:updated>1979-06-21T23:45:00.000Z</atom:updated>
     </item>
@@ -741,6 +757,8 @@ snapshot[`RSS plugin with array function 3`] = `
       <uri>https://oscarotero.com</uri>
     </author>
     <content type="html">Content of Page 5</content>
+    <category term="tag1"/>
+    <category term="tag2"/>
   </entry>
 </feed>',
     data: {
@@ -774,6 +792,8 @@ snapshot[`RSS plugin with array function 3`] = `
       <uri>https://oscarotero.com</uri>
     </author>
     <content type="html">Content of Page 5</content>
+    <category term="tag1"/>
+    <category term="tag2"/>
   </entry>
 </feed>',
       page: [
@@ -790,10 +810,10 @@ snapshot[`RSS plugin with array function 3`] = `
     },
   },
   {
-    content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed2.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
+    content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed2.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","tags":["tag1","tag2"],"date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
     data: {
       basename: "feed2",
-      content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed2.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
+      content: '{"version":"https://jsonfeed.org/version/1.1","title":"My RSS Feed","home_page_url":"https://example.com/","feed_url":"https://example.com/feed2.json","hubs":[{"type":"WebSub","url":"https://example.com/hub1"},{"type":"WebSub","url":"https://example.com/hub2"}],"language":"en","authors":[{"name":"Laura Rubio"}],"icon":"https://example.com/image.png","favicon":"https://example.com/icon.svg","items":[{"id":"https://example.com/page5/","url":"https://example.com/page5/","title":"PAGE 5","language":"gl","authors":[{"name":"Óscar","url":"https://oscarotero.com"}],"content_html":"Content of Page 5","tags":["tag1","tag2"],"date_published":"1979-06-21T23:45:00.000Z","date_modified":"1979-06-21T23:45:00.000Z"}]}',
       page: [
         "src",
         "data",
@@ -834,6 +854,8 @@ snapshot[`RSS plugin with array function 3`] = `
         <uri>https://oscarotero.com</uri>
       </author>
       <content:encoded><![CDATA[Content of Page 5]]></content:encoded>
+      <category>tag1</category>
+      <category>tag2</category>
       <pubDate>Thu, 21 Jun 1979 23:45:00 GMT</pubDate>
       <atom:updated>1979-06-21T23:45:00.000Z</atom:updated>
     </item>
@@ -867,6 +889,8 @@ snapshot[`RSS plugin with array function 3`] = `
         <uri>https://oscarotero.com</uri>
       </author>
       <content:encoded><![CDATA[Content of Page 5]]></content:encoded>
+      <category>tag1</category>
+      <category>tag2</category>
       <pubDate>Thu, 21 Jun 1979 23:45:00 GMT</pubDate>
       <atom:updated>1979-06-21T23:45:00.000Z</atom:updated>
     </item>

--- a/tests/assets/feed/page5.yaml
+++ b/tests/assets/feed/page5.yaml
@@ -1,5 +1,6 @@
 title: Page **5**
 content: Content of Page 5
+tags: [tag1, tag2]
 date: 1979-06-21T23:45:00.000Z
 published: "1979-06-21T23:45:00.000Z"
 author:


### PR DESCRIPTION
<!--Please read the [Code of Conduct](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)-->

## Description

Adds `category` tags to items in both RSS and Atom and the `"tags"` key to JSON Feed items. Defaults to `"=tags"`.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
