### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/core/utils/net.ts
+++ b/core/utils/net.ts
@@ -14,6 +14,11 @@ export function localIp(): string | undefined {
 }
 
 export async function openBrowser(url: string): Promise<void> {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Invalid URL protocol: ${parsed.protocol}`);
+  }
+
   const commands: Record<typeof Deno.build.os, string> = {
     darwin: "open",
     linux: "xdg-open",

--- a/deps/init.ts
+++ b/deps/init.ts
@@ -3,6 +3,11 @@ const res = await fetch(
 );
 const data = await res.json();
 const version = data.versions.shift();
+
+if (typeof version !== "string" || !/^v?\d+\.\d+\.\d+/.test(version)) {
+  throw new Error(`Invalid version: ${version}`);
+}
+
 const { run } = await import(
   `https://cdn.jsdelivr.net/gh/lumeland/init@${version}/mod.ts`
 );


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Critical` | **File**: `deps/init.ts:L1`

The code fetches version data from an external API (jsdelivr) and then dynamically imports modules using that version in the URL template. An attacker who compromises the API or performs a man-in-the-middle attack could inject a malicious version string, leading to arbitrary code execution via the dynamic import. The version is not validated before use.

## Solution

Validate the version string against a strict semantic versioning pattern before using it in the import URL. Consider pinning to known good versions or using a local allowlist.

## Changes

- `deps/init.ts` (modified)
- `core/utils/net.ts` (modified)