### PR TITLE
[icons plugin] Register spriteIcon helper in Lume.Helpers interface

### DIFF
--- a/plugins/icons.ts
+++ b/plugins/icons.ts
@@ -224,6 +224,9 @@ declare global {
     export interface Helpers {
       /** @see https://lume.land/plugins/icons/ */
       icon: (key: string, catalogId: string, rest?: string) => string;
+
+      /** @see https://lume.land/plugins/icons/ */
+      spriteIcon: (key: string, catalogId: string, rest?: string) => string;
     }
   }
 }


### PR DESCRIPTION
## Description

I forgot to add the `spriteIcon` helper to the Lume.Helpers interface.

## Related Issues

Related to #851

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [x] Document any change in the `CHANGELOG.md`.
