### PR TITLE
Strict `merge` utility function; consistent handling of options

### DIFF
--- a/core/server.ts
+++ b/core/server.ts
@@ -4,22 +4,22 @@ import { serveFile as httpServeFile } from "../deps/http.ts";
 
 import type { Event, EventListener, EventOptions } from "./events.ts";
 import { decodeURIComponentSafe } from "./utils/path.ts";
-import { merge } from "./utils/object.ts";
+import { Merge, merge } from "./utils/object.ts";
 
 /** The options to configure the local server */
 export interface Options extends Deno.ServeOptions {
   /** The root path */
-  root: string;
+  root?: string;
   port?: number;
   hostname?: string;
   serveFile?: (root: string, request: Request) => Promise<Response>;
 }
 
-export const defaults: Options = {
+export const defaults = {
   root: `${Deno.cwd()}/_site`,
   port: 8000,
   serveFile,
-};
+} satisfies Options;
 
 export type RequestHandler = (req: Request) => Promise<Response>;
 export type Middleware = (
@@ -47,13 +47,13 @@ export type ServerEventType =
 
 export default class Server {
   events: Events<ServerEvent> = new Events<ServerEvent>();
-  options: Required<Options>;
+  options: Merge<Options, typeof defaults>;
   middlewares: Middleware[] = [];
   fetch: Deno.ServeHandler;
   #server?: Deno.HttpServer;
   #waiting = false;
 
-  constructor(options: Partial<Options> = {}) {
+  constructor(options?: Options) {
     this.options = merge(defaults, options);
 
     if (this.options.hostname === "localhost") {

--- a/core/site.ts
+++ b/core/site.ts
@@ -1,5 +1,5 @@
 import { join, posix } from "../deps/path.ts";
-import { merge } from "./utils/object.ts";
+import { Merge, merge } from "./utils/object.ts";
 import { isUrl, normalizePath } from "./utils/path.ts";
 import { envBoolean, setEnv } from "./utils/env.ts";
 import { log } from "./utils/log.ts";
@@ -43,7 +43,7 @@ import type { ScriptOrFunction } from "./scripts.ts";
 import type { MergeStrategy } from "./utils/merge_data.ts";
 
 /** Default options of the site */
-const defaults: SiteOptions = {
+const defaults = {
   cwd: Deno.cwd(),
   src: "./",
   dest: "./_site",
@@ -69,14 +69,14 @@ const defaults: SiteOptions = {
     dependencies: {},
   },
   components: {},
-};
+} satisfies SiteOptions;
 
 /**
  * This is the heart of Lume,
  * it contains everything needed to build the site
  */
 export default class Site {
-  options: SiteOptions;
+  options: Merge<SiteOptions, typeof defaults>;
 
   /** Internal data. Used to save arbitrary data by plugins and processors */
   _data: Record<string, unknown> = {};
@@ -151,7 +151,7 @@ export default class Site {
   watcher?: FSWatcher;
   server?: Server;
 
-  constructor(options: Partial<SiteOptions> = {}) {
+  constructor(options?: SiteOptions) {
     this.options = merge(defaults, options);
 
     const src = this.src();
@@ -1192,46 +1192,46 @@ export interface ResolveOptions {
 /** The options to configure the site build */
 export interface SiteOptions {
   /** The path of the current working directory */
-  cwd: string;
+  cwd?: string;
 
   /** The path of the site source */
-  src: string;
+  src?: string;
 
   /** The path of the built destination */
-  dest: string;
+  dest?: string;
 
   /** Whether the empty folder should be emptied before the build */
   emptyDest?: boolean;
 
   /** The default includes path */
-  includes: string;
+  includes?: string;
 
   /** The default css file */
-  cssFile: string;
+  cssFile?: string;
 
   /** The default js file */
-  jsFile: string;
+  jsFile?: string;
 
   /** The default folder for fonts */
-  fontsFolder: string;
+  fontsFolder?: string;
 
   /** The site location (used to generate final urls) */
-  location: URL;
+  location?: URL;
 
   /** Set true to generate pretty urls (`/about-me/`) */
-  prettyUrls: boolean;
+  prettyUrls?: boolean;
 
   /** Set true to don't consider two urls the equal if the only difference is the case */
-  caseSensitiveUrls: boolean;
+  caseSensitiveUrls?: boolean;
 
   /** The local server options */
-  server: ServerOptions;
+  server?: ServerOptions;
 
   /** The local watcher options */
-  watcher: WatcherOptions;
+  watcher?: WatcherOptions;
 
   /** The components options */
-  components: ComponentsOptions;
+  components?: ComponentsOptions;
 }
 
 /** The options to configure the local server */
@@ -1243,16 +1243,16 @@ export interface ServerOptions {
   root?: string;
 
   /** The port to listen on */
-  port: number;
+  port?: number;
 
   /** The hostname to listen on */
-  hostname: string;
+  hostname?: string;
 
   /** To open the server in a browser */
-  open: boolean;
+  open?: boolean;
 
   /** The file to serve on 404 error */
-  page404: string;
+  page404?: string;
 
   /**
    * Whether to use the debug bar or not
@@ -1261,22 +1261,22 @@ export interface ServerOptions {
   debugBar?: string | boolean;
 
   /** Optional for the server */
-  middlewares: Middleware[];
+  middlewares?: Middleware[];
 }
 
 /** The options to configure the local watcher */
 export interface WatcherOptions {
   /** Paths to ignore by the watcher */
-  ignore: (string | ((path: string) => boolean))[];
+  ignore?: (string | ((path: string) => boolean))[];
 
   /** The interval in milliseconds to check for changes */
-  debounce: number;
+  debounce?: number;
 
   /** Extra files and folders to watch (ouside the src folder) */
-  include: string[];
+  include?: string[];
 
   /** Manual dependencies not detected by the watcher */
-  dependencies: Record<string, string[]>;
+  dependencies?: Record<string, string[]>;
 }
 
 /** The options to configure the components */

--- a/core/slugifier.ts
+++ b/core/slugifier.ts
@@ -21,7 +21,7 @@ export interface Options {
   stopWords?: string[];
 }
 
-export const defaults: Options = {
+export const defaults = {
   lowercase: true,
   alphanumeric: true,
   separator: "-",
@@ -36,7 +36,7 @@ export const defaults: Options = {
     "œ": "oe",
   },
   stopWords: [],
-};
+} satisfies Options;
 
 export default function createSlugifier(
   userOptions?: Options,

--- a/core/utils/cli_options.ts
+++ b/core/utils/cli_options.ts
@@ -1,12 +1,11 @@
 import { parseArgs } from "../../deps/cli.ts";
 import { getFreePort } from "./net.ts";
 
-import type { DeepPartial } from "./object.ts";
 import type { SiteOptions } from "../site.ts";
 
 export function getOptionsFromCli(
-  options: DeepPartial<SiteOptions>,
-): DeepPartial<SiteOptions> {
+  options: SiteOptions,
+): SiteOptions {
   const cli = parseArgs(Deno.args, {
     string: ["src", "dest", "location", "port", "hostname"],
     boolean: ["serve", "open"],

--- a/core/utils/object.ts
+++ b/core/utils/object.ts
@@ -12,7 +12,8 @@ export function isPlainObject(obj: unknown): obj is Record<string, unknown> {
 }
 
 /** TypeScript helper to deep merge an optiosn object with some defaults */
-export type Merge<T, D extends Partial<T>> = T extends unknown[] ? T
+export type Merge<T, D extends Partial<T>> = T extends RegExp | URL | unknown[]
+  ? T
   : T extends object ?
       & T
       & {

--- a/core/utils/object.ts
+++ b/core/utils/object.ts
@@ -1,12 +1,6 @@
 const ssxElement = Symbol.for("ssx.element");
 const objectConstructor = {}.constructor;
 
-/** TypeScript helper to create optional properties recursively */
-export type DeepPartial<T> = T extends object ? {
-    [P in keyof T]?: DeepPartial<T[P]>;
-  }
-  : T;
-
 /** Check if the argument passed is a plain object */
 export function isPlainObject(obj: unknown): obj is Record<string, unknown> {
   return typeof obj === "object" && obj !== null &&

--- a/core/utils/object.ts
+++ b/core/utils/object.ts
@@ -17,18 +17,30 @@ export function isPlainObject(obj: unknown): obj is Record<string, unknown> {
     obj !== obj.page?.data;
 }
 
+/** TypeScript helper to deep merge an optiosn object with some defaults */
+export type Merge<T, D extends Partial<T>> = T extends unknown[] ? T
+  : T extends object ?
+      & T
+      & {
+        // deno-lint-ignore ban-types
+        [K in keyof T & keyof D]: D[K] extends {} ? Merge<T[K], D[K]> : unknown;
+      }
+  // deno-lint-ignore ban-types
+  : D extends {} ? NonNullable<T>
+  : T;
+
 /**
  * Merge two objects recursively.
  * It's used to merge user options with default options.
  */
-export function merge<Type>(
-  defaults: Type,
+export function merge<Type, Def extends Partial<Type>>(
+  defaults: Def,
   user?: Type,
-): Required<Type> {
+): Merge<Type, Def> {
   const merged = { ...defaults };
 
   if (!user) {
-    return merged as unknown as Required<Type>;
+    return merged as unknown as Merge<Type, Def>;
   }
 
   for (const [key, value] of Object.entries(user)) {
@@ -47,5 +59,5 @@ export function merge<Type>(
     merged[key] = value;
   }
 
-  return merged as unknown as Required<Type>;
+  return merged as unknown as Merge<Type, Def>;
 }

--- a/middlewares/basic_auth.ts
+++ b/middlewares/basic_auth.ts
@@ -4,22 +4,22 @@ import type { Middleware, RequestHandler } from "../core/server.ts";
 
 export interface Options {
   /** The realm to show in the authentication dialog */
-  realm: string;
+  realm?: string;
   /** The users and passwords to use for authentication */
-  users: Record<string, string>;
+  users?: Record<string, string>;
   /** The error message to show when authentication fails */
-  errorMessage: string;
+  errorMessage?: string;
 }
 
-export const defaults: Options = {
+export const defaults = {
   realm: "Basic Authentication",
   users: {},
   errorMessage: "401 Unauthorized",
-};
+} satisfies Options;
 
 // Code from https://deno.land/x/basic_auth@v1.0.1/mod.ts
 export function basicAuth(
-  userOptions?: Partial<Options>,
+  userOptions?: Options,
 ): Middleware {
   const options = merge(defaults, userOptions);
 

--- a/middlewares/cache_busting.ts
+++ b/middlewares/cache_busting.ts
@@ -1,20 +1,21 @@
 import type { Middleware } from "../core/server.ts";
+import { merge } from "../core/utils/object.ts";
 
 export interface Options {
   /** The regex to match the cache busting pattern */
-  regex: RegExp;
+  regex?: RegExp;
   /** The replacement string */
-  replacement: string;
+  replacement?: string;
 }
 
-export const defaults: Options = {
+export const defaults = {
   regex: /^\/v[\d]+\//,
   replacement: "/",
-};
+} satisfies Options;
 
 /** Implements cache busting */
-export function cacheBusting(options?: Partial<Options>): Middleware {
-  const { regex, replacement } = { ...defaults, ...options };
+export function cacheBusting(options?: Options): Middleware {
+  const { regex, replacement } = merge(defaults, options);
 
   return async (request, next) => {
     const url = new URL(request.url);

--- a/middlewares/expires.ts
+++ b/middlewares/expires.ts
@@ -1,4 +1,5 @@
 import type { Middleware } from "../core/server.ts";
+import { merge } from "../core/utils/object.ts";
 
 const HOUR = 3600000;
 const DAY = HOUR * 24;
@@ -12,7 +13,7 @@ export interface Options {
   durations: Record<string, number>;
 }
 
-export const defaults: Options = {
+export const defaults = {
   defaultDuration: WEEK,
   durations: {
     "text/html": 0,
@@ -22,11 +23,11 @@ export const defaults: Options = {
     "application/rdf+xml": HOUR,
     "application/rss+xml": HOUR,
   },
-};
+} satisfies Options;
 
 /** Set the Expires header for better caching */
-export function expires(userOptions?: Partial<Options>): Middleware {
-  const options = { ...defaults, ...userOptions };
+export function expires(userOptions?: Options): Middleware {
+  const options = merge(defaults, userOptions);
 
   return async (request, next) => {
     const response = await next(request);

--- a/middlewares/not_found.ts
+++ b/middlewares/not_found.ts
@@ -5,21 +5,21 @@ import type { Middleware } from "../core/server.ts";
 
 export interface Options {
   /** The root folder to look for the 404 page */
-  root: string;
+  root?: string;
   /** The path to the 404 page */
-  page404: string;
+  page404?: string;
   /** Show the directory index if the page404 is not found */
   directoryIndex?: boolean;
 }
 
-export const defaults: Options = {
+export const defaults = {
   root: `${Deno.cwd()}/_site`,
   page404: "/404.html",
   directoryIndex: false,
-};
+} satisfies Options;
 
 /** Show a 404 page */
-export function notFound(userOptions?: Partial<Options>): Middleware {
+export function notFound(userOptions?: Options): Middleware {
   const options = merge(defaults, userOptions);
   let { root, page404, directoryIndex } = options;
 

--- a/middlewares/precompress.ts
+++ b/middlewares/precompress.ts
@@ -10,12 +10,12 @@ export interface Options {
   encodings: Record<string, string>;
 }
 
-export const defaults: Options = {
+export const defaults = {
   encodings: {
     br: ".br",
     gzip: ".gz",
   },
-};
+} satisfies Options;
 
 export function preCompress(userOptions?: Options): Middleware {
   const options = merge(defaults, userOptions);

--- a/middlewares/shutdown.ts
+++ b/middlewares/shutdown.ts
@@ -1,25 +1,26 @@
 import type { Middleware } from "../core/server.ts";
+import { merge } from "../core/utils/object.ts";
 
 export interface Options {
   /** The path to the shutdown page */
-  page: string;
+  page?: string;
 
   /**
    * The time in seconds to retry after.
    * @default 60 * 60 * 24 (24 hours)
    */
-  retryAfter: number;
+  retryAfter?: number;
 }
 
-export const defaults: Options = {
+export const defaults = {
   page: "/503.html",
   retryAfter: 60 * 60 * 24, // 24 hours
-};
+} satisfies Options;
 
 export function shutdown(
-  userOptions?: Partial<Options>,
+  userOptions?: Options,
 ): Middleware {
-  const options = { ...defaults, ...userOptions };
+  const options = merge(defaults, userOptions);
 
   return async (request, next) => {
     if (!isHtml(request)) {

--- a/middlewares/www.ts
+++ b/middlewares/www.ts
@@ -1,20 +1,21 @@
 import type { Middleware } from "../core/server.ts";
+import { merge } from "../core/utils/object.ts";
 
 export interface Options {
   /** To add or remove the www */
-  add: boolean;
+  add?: boolean;
   /** The status code to use for the redirect */
-  code: 301 | 302 | 307 | 308;
+  code?: 301 | 302 | 307 | 308;
 }
 
-export const defaults: Options = {
+export const defaults = {
   add: false,
   code: 301,
-};
+} satisfies Options;
 
 /** Middleware to add/remove the www. domain */
-export function www(userOptions?: Partial<Options>): Middleware {
-  const options = { ...defaults, ...userOptions };
+export function www(userOptions?: Options): Middleware {
+  const options = merge(defaults, userOptions);
 
   return async (request, next) => {
     const url = new URL(request.url);

--- a/mod.ts
+++ b/mod.ts
@@ -10,7 +10,6 @@ import toml, { Options as TomlOptions } from "./plugins/toml.ts";
 import yaml, { Options as YamlOptions } from "./plugins/yaml.ts";
 import { getOptionsFromCli } from "./core/utils/cli_options.ts";
 
-import type { DeepPartial } from "./core/utils/object.ts";
 import type { SiteOptions } from "./core/site.ts";
 
 export interface PluginOptions {
@@ -24,7 +23,7 @@ export interface PluginOptions {
 }
 
 export default function lume(
-  options: DeepPartial<SiteOptions> = {},
+  options: SiteOptions = {},
   pluginOptions: PluginOptions = {},
   cliOptions = true,
 ): Site {
@@ -32,7 +31,7 @@ export default function lume(
     getOptionsFromCli(options);
   }
 
-  const site = new Site(options as Partial<SiteOptions>);
+  const site = new Site(options);
 
   // Ignore some files by the watcher
   site.options.watcher.ignore.push("/deno.lock");

--- a/plugins/brotli.ts
+++ b/plugins/brotli.ts
@@ -12,9 +12,9 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".html", ".css", ".js", ".mjs", ".svg", ".json", ".xml", ".txt"],
-};
+} satisfies Options;
 
 /**
  * A plugin to compress files with brotli

--- a/plugins/check_urls.ts
+++ b/plugins/check_urls.ts
@@ -28,12 +28,13 @@ export interface Options {
 }
 
 /** Default options */
-export const defaults: Options = {
+export const defaults = {
   strict: false,
   throw: false,
   ignore: [],
   external: false,
-};
+  anchors: false,
+} satisfies Options;
 
 const cacheExternalUrls = new Map<string, Promise<boolean>>();
 const cacheInternalUrls = new Map<string, boolean>();
@@ -53,7 +54,7 @@ export default function (userOptions?: Options) {
     }
 
     return !url ||
-      options.ignore?.includes(url) ||
+      options.ignore.includes(url) ||
       url.startsWith("?") ||
       (url.startsWith("#") && !options.anchors);
   }

--- a/plugins/code_highlight.ts
+++ b/plugins/code_highlight.ts
@@ -40,7 +40,7 @@ interface Theme {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   options: {
     ignoreUnescapedHTML: false,
     noHighlightRe: /^$/i,
@@ -49,7 +49,7 @@ export const defaults: Options = {
     cssSelector: "pre code",
     languages: undefined,
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to syntax-highlight code using the highlight.js library
@@ -76,10 +76,10 @@ export function codeHighlight(userOptions?: Options) {
     site.process([".html"], processCodeHighlight);
 
     if (options.theme) {
+      const theme = options.theme;
+
       site.process(async function processCodeHighlightTheme() {
-        const themes = Array.isArray(options.theme)
-          ? options.theme
-          : [options.theme];
+        const themes = Array.isArray(theme) ? theme : [theme];
 
         for (
           const { name, cssFile = site.options.cssFile, placeholder } of themes

--- a/plugins/date.ts
+++ b/plugins/date.ts
@@ -18,7 +18,7 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   locales: {},
   formats: {
     ATOM: "yyyy-MM-dd'T'HH:mm:ssXXX",
@@ -28,7 +28,7 @@ export const defaults: Options = {
     HUMAN_DATE: "PPP",
     HUMAN_DATETIME: "PPPppp",
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to format Date values

--- a/plugins/decap_cms.ts
+++ b/plugins/decap_cms.ts
@@ -30,14 +30,14 @@ export interface Options {
   proxyCommand?: string;
 }
 
-export const defaults: Options = {
+export const defaults = {
   local: undefined,
   path: "/admin/",
   configKey: "decap_cms",
   extraHTML: "",
   proxyCommand:
     `deno run --allow-read --allow-net=0.0.0.0 --allow-write --allow-env ${serverUrl}`,
-};
+} satisfies Options;
 
 /**
  * A plugin to use Decap CMS in Lume easily

--- a/plugins/epub.ts
+++ b/plugins/epub.ts
@@ -28,7 +28,7 @@ export interface Options {
   metadata?: Partial<Metadata>;
 }
 
-export const defaults: Options = {
+export const defaults = {
   output: "/book.epub",
   outputUncompressed: false,
   metadata: {
@@ -38,7 +38,7 @@ export const defaults: Options = {
     rights: "All rights reserved",
     date: new Date(),
   },
-};
+} satisfies Options;
 
 export default function (userOptions?: Options) {
   const options = merge(defaults, userOptions);

--- a/plugins/esbuild.ts
+++ b/plugins/esbuild.ts
@@ -34,7 +34,7 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".ts", ".js", ".tsx", ".jsx"],
   options: {
     plugins: [],
@@ -55,7 +55,7 @@ export const defaults: Options = {
     outdir: "./",
     outbase: ".",
   },
-};
+} satisfies Options;
 
 let resolver: ((specifier: string, referrer?: string) => string) | undefined;
 

--- a/plugins/eta.ts
+++ b/plugins/eta.ts
@@ -25,13 +25,13 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".eta"],
   includes: "",
   options: {
     useWith: true,
   },
-};
+} satisfies Options;
 
 /** Template engine to render Eta files */
 export class EtaEngine implements Engine {

--- a/plugins/extract_date.ts
+++ b/plugins/extract_date.ts
@@ -9,9 +9,9 @@ export interface Options {
   remove?: boolean;
 }
 
-export const defaults: Options = {
+export const defaults = {
   remove: true,
-};
+} satisfies Options;
 
 /**
  * A plugin to extract the date from the files and folders paths

--- a/plugins/extract_order.ts
+++ b/plugins/extract_order.ts
@@ -9,10 +9,10 @@ export interface Options {
   cascade?: boolean;
 }
 
-export const defaults: Options = {
+export const defaults = {
   remove: true,
   cascade: false,
-};
+} satisfies Options;
 
 const ORDER_REGEX = /(\d+)\.(.+)/;
 

--- a/plugins/favicon.ts
+++ b/plugins/favicon.ts
@@ -21,7 +21,7 @@ export interface Options {
   favicons?: Favicon[];
 }
 
-export const defaults: Options = {
+export const defaults = {
   input: "/favicon.svg",
   favicons: [
     {
@@ -37,7 +37,7 @@ export const defaults: Options = {
       format: "png",
     },
   ],
-};
+} satisfies Options;
 
 export interface Favicon {
   url: string;

--- a/plugins/feed.ts
+++ b/plugins/feed.ts
@@ -114,7 +114,7 @@ export interface FeedItemOptions {
   authorUrl?: string;
 }
 
-export const defaults: Options = {
+export const defaults = {
   /** The output filenames */
   output: "/feed.rss",
 
@@ -143,7 +143,7 @@ export const defaults: Options = {
     categories: "=tags",
     lang: "=lang",
   },
-};
+} satisfies Options;
 
 export interface Author {
   name?: string;

--- a/plugins/fff.ts
+++ b/plugins/fff.ts
@@ -16,8 +16,8 @@ export interface Options {
    * The list of presets to apply
    * @see https://fff.js.org/concepts/flavor-transform.html#fff-transform-preset
    */
-  presets: FFFTransformPreset[];
-  strict: false | StrictPresetOptions;
+  presets?: FFFTransformPreset[];
+  strict?: false | StrictPresetOptions;
   /** To convert the generic `date` field to one of these values */
   date?: "created" | "updated" | "published";
   /** Get the date from the git history */
@@ -26,16 +26,16 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   presets: [],
   strict: false,
-};
+} satisfies Options;
 
 /**
  * A plugin to transform frontmatter using FFF
  * @see https://lume.land/plugins/fff/
  */
-export function fff(userOptions?: Partial<Options>) {
+export function fff(userOptions?: Options) {
   const options = merge(defaults, userOptions);
 
   return (site: Site) => {

--- a/plugins/filter_pages.ts
+++ b/plugins/filter_pages.ts
@@ -17,10 +17,10 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   fn: () => true,
   beforeRender: false,
-};
+} satisfies Options;
 
 /**
  * A plugin to filter pages

--- a/plugins/google_fonts.ts
+++ b/plugins/google_fonts.ts
@@ -27,9 +27,9 @@ export interface Options {
   ignoredSubsets?: string[];
 }
 
-export const defaults: Options = {
+export const defaults = {
   fonts: "",
-};
+} satisfies Options;
 
 export function googleFonts(userOptions: Options) {
   const options = merge(defaults, userOptions);

--- a/plugins/gzip.ts
+++ b/plugins/gzip.ts
@@ -12,9 +12,9 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".html", ".css", ".js", ".mjs", ".svg", ".json", ".xml", ".txt"],
-};
+} satisfies Options;
 
 /**
  * A plugin to compress files with gzip

--- a/plugins/icons.ts
+++ b/plugins/icons.ts
@@ -19,11 +19,11 @@ export interface Options {
   catalogs?: Catalog[];
 }
 
-export const defaults: Options = {
+export const defaults = {
   folder: "/icons",
   spriteFile: "/icons.svg",
   catalogs,
-};
+} satisfies Options;
 
 export function icons(userOptions?: Options) {
   const options = merge(defaults, userOptions);

--- a/plugins/inline.ts
+++ b/plugins/inline.ts
@@ -18,10 +18,10 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   copyAttributes: [/^data-/],
   sourceURL: false,
-};
+} satisfies Options;
 
 const cache = new Map();
 const XML_DECLARATION_REGEX = /<\?xml[\s\S]*?\?>/;

--- a/plugins/json.ts
+++ b/plugins/json.ts
@@ -12,10 +12,10 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".json", ".jsonc"],
   pageSubExtension: ".page",
-};
+} satisfies Options;
 
 /**
  * A plugin to load JSON files as data and pages

--- a/plugins/jsx.ts
+++ b/plugins/jsx.ts
@@ -20,10 +20,10 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".jsx", ".tsx"],
   pageSubExtension: ".page",
-};
+} satisfies Options;
 
 /** Template engine to render JSX files */
 export class JsxEngine implements Engine {

--- a/plugins/katex.ts
+++ b/plugins/katex.ts
@@ -34,7 +34,7 @@ export interface Options {
   options?: KatexOptions;
 }
 
-export const defaults: Options = {
+export const defaults = {
   cssSelector: ".language-math",
   options: {
     strict: true,
@@ -62,7 +62,7 @@ export const defaults: Options = {
     ignoredClasses: [],
     macros: {},
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to render math equations using katex

--- a/plugins/lightningcss.ts
+++ b/plugins/lightningcss.ts
@@ -32,7 +32,7 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   includes: "",
   options: {
     minify: true,
@@ -48,7 +48,7 @@ export const defaults: Options = {
       safari: version(browsers.safari),
     },
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to process CSS files with lightningcss
@@ -56,7 +56,7 @@ export const defaults: Options = {
  */
 export function lightningCSS(userOptions?: Options) {
   return (site: Site) => {
-    const options = merge<Options>(
+    const options = merge(
       { ...defaults, includes: site.options.includes },
       userOptions,
     );

--- a/plugins/lume_cms.ts
+++ b/plugins/lume_cms.ts
@@ -18,9 +18,9 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Partial<Options> = {
+export const defaults = {
   basePath: "/admin",
-};
+} satisfies Partial<Options>;
 
 /**
  * A plugin to use LumeCMS

--- a/plugins/markdown.ts
+++ b/plugins/markdown.ts
@@ -32,7 +32,7 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".md", ".markdown"],
   options: {
     html: true,
@@ -40,7 +40,7 @@ export const defaults: Options = {
   plugins: [],
   rules: {},
   useDefaultPlugins: true,
-};
+} satisfies Options;
 
 const defaultPlugins = [
   markdownItAttrs,

--- a/plugins/mdx.ts
+++ b/plugins/mdx.ts
@@ -1,5 +1,5 @@
 import loader from "../core/loaders/text.ts";
-import { merge } from "../core/utils/object.ts";
+import { Merge, merge } from "../core/utils/object.ts";
 import { compile, remarkGfm } from "../deps/mdx.ts";
 import { join, toFileUrl } from "../deps/path.ts";
 import { renderComponent } from "../deps/ssx.ts";
@@ -41,10 +41,11 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".mdx"],
   useDefaultPlugins: true,
-};
+  includes: "", // Will be overwritten
+} satisfies Options;
 
 const remarkDefaultPlugins = [
   remarkGfm,
@@ -53,11 +54,11 @@ const remarkDefaultPlugins = [
 /** Template engine to render Markdown files with Remark */
 export class MDXEngine implements Engine<string | { toString(): string }> {
   baseUrl: string;
-  options: Required<Options>;
+  options: Merge<Options, typeof defaults>;
   includes: string;
   filters: Record<string, Helper> = {};
 
-  constructor(baseUrl: string, options: Required<Options>) {
+  constructor(baseUrl: string, options: Merge<Options, typeof defaults>) {
     this.baseUrl = baseUrl;
     this.options = options;
     this.includes = options.includes;

--- a/plugins/minify_html.ts
+++ b/plugins/minify_html.ts
@@ -15,7 +15,7 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".html"],
   options: {
     do_not_minify_doctype: true,
@@ -27,7 +27,7 @@ export const defaults: Options = {
     remove_bangs: false,
     remove_processing_instructions: false,
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to minify HTML, CSS & JavaScript files

--- a/plugins/modify_urls.ts
+++ b/plugins/modify_urls.ts
@@ -15,9 +15,9 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   fn: (url) => url,
-};
+} satisfies Options;
 
 /**
  * A plugin to modify all URLs found in HTML and CSS documents

--- a/plugins/modules.ts
+++ b/plugins/modules.ts
@@ -19,10 +19,10 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".js", ".ts"],
   pageSubExtension: ".page",
-};
+} satisfies Options;
 
 /** Template engine to render js/ts files */
 export class ModuleEngine implements Engine {

--- a/plugins/multilanguage.ts
+++ b/plugins/multilanguage.ts
@@ -17,9 +17,9 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   languages: [],
-};
+} satisfies Options;
 
 /**
  * A plugin to create multilanguage websites

--- a/plugins/nav.ts
+++ b/plugins/nav.ts
@@ -11,9 +11,9 @@ export interface Options {
   order?: string;
 }
 
-export const defaults: Options = {
+export const defaults = {
   order: "basename=asc-locale",
-};
+} satisfies Options;
 
 /**
  * A plugin to generate a navigation tree and breadcrumbs

--- a/plugins/nunjucks.ts
+++ b/plugins/nunjucks.ts
@@ -35,11 +35,11 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".njk"],
   options: {},
   plugins: {},
-};
+} satisfies Options;
 
 /** Template engine to render Nunjucks files */
 export class NunjucksEngine implements Engine {

--- a/plugins/og_images.ts
+++ b/plugins/og_images.ts
@@ -23,13 +23,13 @@ export interface Options {
   options?: Partial<SatoriOptions>;
 }
 
-export const defaults: Options = {
+export const defaults = {
   options: {
     width: 1200,
     height: 600,
     fonts: [],
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to generate Open Graph images for your pages

--- a/plugins/pagefind.ts
+++ b/plugins/pagefind.ts
@@ -120,7 +120,7 @@ export interface Options {
   customRecords?: CustomRecord[];
 }
 
-export const defaults: Options = {
+export const defaults = {
   outputPath: "/pagefind",
   ui: {
     containerId: "search",
@@ -135,7 +135,7 @@ export const defaults: Options = {
     verbose: false,
     excludeSelectors: [],
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to generate a static full text search engine

--- a/plugins/paginate.ts
+++ b/plugins/paginate.ts
@@ -1,4 +1,4 @@
-import { merge } from "../core/utils/object.ts";
+import { Merge, merge } from "../core/utils/object.ts";
 
 import type Site from "../core/site.ts";
 
@@ -62,11 +62,12 @@ export interface Options {
   options?: PaginateOptions;
 }
 
-export const defaults: Options = {
+export const defaults = {
   options: {
     size: 10,
+    url: () => "", // Will be overwritten
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to paginate pages
@@ -87,8 +88,10 @@ export function paginate(userOptions?: Options) {
   };
 }
 
+type CreatePaginatorOptions = Merge<Options, typeof defaults>["options"];
+
 /** Create a paginator function */
-export function createPaginator(defaults: PaginateOptions): Paginator {
+export function createPaginator(defaults: CreatePaginatorOptions): Paginator {
   return function paginate<T>(
     results: T[],
     userOptions: Partial<PaginateOptions> = {},

--- a/plugins/partytown.ts
+++ b/plugins/partytown.ts
@@ -11,11 +11,11 @@ export interface Options {
   options?: PartytownConfig;
 }
 
-export const defaults: Options = {
+export const defaults = {
   options: {
     lib: "/~partytown/",
   },
-};
+} satisfies Options;
 
 export function partytown(userOptions?: Options) {
   const options = merge(defaults, userOptions);

--- a/plugins/picture.ts
+++ b/plugins/picture.ts
@@ -23,9 +23,9 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   order: ["avif", "webp", "png", "jpg"],
-};
+} satisfies Options;
 
 /**
  * A plugin to transform images to different formats and sizes

--- a/plugins/postcss.ts
+++ b/plugins/postcss.ts
@@ -32,9 +32,9 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   useDefaultPlugins: true,
-};
+} satisfies Options;
 
 const defaultPlugins = [
   autoprefixer({
@@ -55,7 +55,7 @@ const defaultPlugins = [
  */
 export function postCSS(userOptions?: Options) {
   return (site: Site) => {
-    const options = merge<Options>(
+    const options = merge(
       { ...defaults, includes: site.options.includes },
       userOptions,
     );

--- a/plugins/prism.ts
+++ b/plugins/prism.ts
@@ -38,10 +38,10 @@ interface Theme {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   cssSelector: "pre code",
   autoloadLanguages: false,
-};
+} satisfies Options;
 
 /**
  * A plugin to syntax-highlight code using Prism library

--- a/plugins/pug.ts
+++ b/plugins/pug.ts
@@ -28,10 +28,10 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".pug"],
   options: {},
-};
+} satisfies Options;
 
 type Compiler = typeof compile;
 

--- a/plugins/purgecss.ts
+++ b/plugins/purgecss.ts
@@ -16,12 +16,12 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   contentExtensions: [".html", ".js"],
   options: {
     extractors: [],
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to remove unused CSS

--- a/plugins/reading_info.ts
+++ b/plugins/reading_info.ts
@@ -10,10 +10,10 @@ export interface Options {
   wordsPerMinute?: number;
 }
 
-export const defaults: Options = {
+export const defaults = {
   extensions: [".md"],
   wordsPerMinute: 275,
-};
+} satisfies Options;
 
 /**
  * A plugin to calculate the reading time of a content

--- a/plugins/redirects.ts
+++ b/plugins/redirects.ts
@@ -19,10 +19,10 @@ type OutputStrategy = (
   site: Site,
 ) => Promise<void> | void;
 
-export const defaults: Options = {
+export const defaults = {
   output: "html",
   defaultStatus: 301,
-};
+} satisfies Options;
 
 /** Predefined output strategies */
 const outputs: Record<string, OutputStrategy> = {

--- a/plugins/relations.ts
+++ b/plugins/relations.ts
@@ -28,12 +28,12 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".html"],
   idKey: "id",
   typeKey: "type",
   foreignKeys: {},
-};
+} satisfies Options;
 
 /**
  * A plugin to create relations between pages

--- a/plugins/remark.ts
+++ b/plugins/remark.ts
@@ -39,14 +39,14 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".md"],
   sanitize: false,
   useDefaultPlugins: true,
   rehypeOptions: {
     allowDangerousHtml: true,
   },
-};
+} satisfies Options;
 
 const remarkDefaultPlugins = [
   remarkGfm,
@@ -97,7 +97,7 @@ export function remark(userOptions?: Options) {
     }
 
     // Add remark plugins
-    plugins.push(...options.remarkPlugins);
+    plugins.push(...options.remarkPlugins ?? []);
 
     // Add remark-rehype to generate HAST
     plugins.push([remarkRehype, options.rehypeOptions ?? {}]);

--- a/plugins/replace.ts
+++ b/plugins/replace.ts
@@ -10,10 +10,10 @@ export interface Options {
   replacements: Record<string, string | ((text: string) => string)>;
 }
 
-export const defaults: Options = {
+export const defaults = {
   extensions: [".html"],
   replacements: {},
-};
+} satisfies Options;
 
 export default function replace(userOptions?: Options) {
   const options = merge(defaults, userOptions);

--- a/plugins/robots.ts
+++ b/plugins/robots.ts
@@ -36,7 +36,7 @@ const ruleSort = [
 
 export interface Options {
   /** The robots.txt file name */
-  filename: string;
+  filename?: string;
 
   /** User-agent to allow */
   allow?: string[] | string;
@@ -49,17 +49,17 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   filename: "/robots.txt",
   allow: "*",
-};
+} satisfies Options;
 
 /**
  * A plugin to generate a robots.txt after build
  * @see https://lume.land/plugins/robots/
  */
-export function robots(userOptions?: Partial<Options>) {
-  const options: Options = merge(defaults, userOptions);
+export function robots(userOptions?: Options) {
+  const options = merge(defaults, userOptions);
 
   return (site: Site) => {
     site.process(async function processRobots() {

--- a/plugins/sass.ts
+++ b/plugins/sass.ts
@@ -33,10 +33,10 @@ export interface Options {
   includes?: string;
 }
 
-export const defaults: Options = {
+export const defaults = {
   format: "compressed",
   options: {},
-};
+} satisfies Options;
 
 /**
  * A plugin to process SASS and SCSS files

--- a/plugins/seo.ts
+++ b/plugins/seo.ts
@@ -21,7 +21,7 @@ export interface Options {
   options?: SeoOptions;
 }
 
-export const defaults: Options = {
+export const defaults = {
   output: false,
   options: {
     commonWords,
@@ -56,7 +56,7 @@ export const defaults: Options = {
       unit: "word",
     },
   },
-};
+} satisfies Options;
 
 export function SEO(userOptions?: Options) {
   const options = merge(defaults, userOptions);

--- a/plugins/sheets.ts
+++ b/plugins/sheets.ts
@@ -32,14 +32,14 @@ export interface Options {
   outputOptions?: Sheet2JSONOpts;
 }
 
-export const defaults: Options = {
+export const defaults = {
   extensions: [".xlsx", ".numbers", ".csv"],
   sheets: "auto",
   options: {},
   outputOptions: {
     UTC: true,
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to load Excel, Numbers, and CSV files

--- a/plugins/sitemap.ts
+++ b/plugins/sitemap.ts
@@ -47,14 +47,14 @@ export interface SitemapItemsOptions {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   filename: "/sitemap.xml",
   query: "unlisted!=true",
   sort: "url=asc",
   items: {
     lastmod: "=date",
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to generate a sitemap.xml from page files after build

--- a/plugins/slugify_urls.ts
+++ b/plugins/slugify_urls.ts
@@ -15,10 +15,10 @@ export interface Options extends SlugifierOptions {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".html"],
   ...slugifierDefaults,
-};
+} satisfies Options;
 
 /**
  * A plugin to slugify all URLs, replacing non-URL-safe characters

--- a/plugins/source_maps.ts
+++ b/plugins/source_maps.ts
@@ -16,10 +16,10 @@ export interface Options {
   sourceContent?: boolean;
 }
 
-export const defaults: Options = {
+export const defaults = {
   inline: false,
   sourceContent: true,
-};
+} satisfies Options;
 
 /**
  * A plugin to manage source maps

--- a/plugins/sri.ts
+++ b/plugins/sri.ts
@@ -13,11 +13,11 @@ export interface Options {
   selector?: string;
 }
 
-export const defaults: Options = {
+export const defaults = {
   algorithm: "sha384",
   crossorigin: "anonymous",
   selector: "script[src], link[rel=stylesheet][href]",
-};
+} satisfies Options;
 
 const cache = new Map<string, string>();
 
@@ -25,7 +25,7 @@ const cache = new Map<string, string>();
  * A plugin to add the Subresource Integrity (SRI) attribute to the script and link elements
  * @see https://lume.land/plugins/sri/
  */
-export function sri(userOptions?: Partial<Options>) {
+export function sri(userOptions?: Options) {
   const options = merge(defaults, userOptions);
 
   return (site: Site) => {

--- a/plugins/svgo.ts
+++ b/plugins/svgo.ts
@@ -13,7 +13,7 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {};
+export const defaults = {} satisfies Options;
 
 /**
  * A plugin to load all SVG files and minify them using SVGO

--- a/plugins/tailwindcss.ts
+++ b/plugins/tailwindcss.ts
@@ -27,7 +27,7 @@ export interface Options {
   minify?: boolean;
 }
 
-export const defaults: Options = {};
+export const defaults = {} satisfies Options;
 
 /**
  * A plugin to extract the utility classes from HTML pages and apply TailwindCSS
@@ -35,7 +35,7 @@ export const defaults: Options = {};
  */
 export function tailwindCSS(userOptions?: Options) {
   return (site: Site) => {
-    const options = merge<Options>(
+    const options = merge(
       { ...defaults, includes: site.options.includes },
       userOptions,
     );

--- a/plugins/terser.ts
+++ b/plugins/terser.ts
@@ -22,14 +22,14 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".js"],
   options: {
     module: true,
     compress: true,
     mangle: true,
   },
-};
+} satisfies Options;
 
 /**
  * A plugin to minify them using Terser

--- a/plugins/toml.ts
+++ b/plugins/toml.ts
@@ -12,10 +12,10 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".toml"],
   pageSubExtension: ".page",
-};
+} satisfies Options;
 
 /**
  * A plugin to load TOML data files and pages

--- a/plugins/transform_images.ts
+++ b/plugins/transform_images.ts
@@ -1,7 +1,7 @@
 import { getExtension, getPathAndExtension } from "../core/utils/path.ts";
 import { filesToPages } from "../core/file.ts";
 import { log, warnUntil } from "../core/utils/log.ts";
-import { merge } from "../core/utils/object.ts";
+import { Merge, merge } from "../core/utils/object.ts";
 import { concurrent } from "../core/utils/concurrent.ts";
 import sharp, { create } from "../deps/sharp.ts";
 
@@ -10,7 +10,7 @@ import type { Page, StaticFile } from "../core/file.ts";
 
 export interface Options {
   /** Custom transform functions */
-  functions: Record<string, TransformationFunction>;
+  functions?: Record<string, TransformationFunction>;
   /** Limit number of images processed concurrently. Uses global concurrency limit if not set. */
   concurrency?: number;
 }
@@ -22,7 +22,7 @@ export type TransformationFunction = (
 ) => void;
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   functions: {
     resize(
       image: sharp.Sharp,
@@ -40,7 +40,7 @@ export const defaults: Options = {
     },
   },
   concurrency: 10,
-};
+} satisfies Options;
 const supportedExtensions = new Set([
   ".jpg",
   ".jpeg",
@@ -87,7 +87,7 @@ interface SingleTransformation extends Transformation {
  * A plugin to transform images in Lume
  * @see https://lume.land/plugins/transform_images/
  */
-export function transformImages(userOptions?: Partial<Options>) {
+export function transformImages(userOptions?: Options) {
   const options = merge(defaults, userOptions);
 
   return (site: Site) => {
@@ -189,7 +189,7 @@ async function transform(
   content: Uint8Array | string,
   page: Page,
   transformation: Transformation,
-  options: Options,
+  options: Merge<Options, typeof defaults>,
 ): Promise<void> {
   const ext = page.src.ext;
   const format = transformation.format;

--- a/plugins/unocss.ts
+++ b/plugins/unocss.ts
@@ -59,7 +59,7 @@ export interface Options {
   reset?: false | "tailwind" | "tailwind-compat" | "eric-meyer";
 }
 
-export const defaults: Options = {
+export const defaults = {
   options: {
     presets: [presetWind3],
   },
@@ -68,7 +68,7 @@ export const defaults: Options = {
     transformerDirectives(),
   ],
   reset: false,
-};
+} satisfies Options;
 
 /**
  * A plugin to generate CSS using UnoCSS

--- a/plugins/validate_html.ts
+++ b/plugins/validate_html.ts
@@ -30,7 +30,7 @@ export interface Options {
   output?: string | ((report: Report) => void);
 }
 
-export const defaults: Options = {
+export const defaults = {
   extends: ["html-validate:recommended", "html-validate:document"],
   rules: {
     "doctype-style": "off",
@@ -39,7 +39,7 @@ export const defaults: Options = {
     "void-style": "warn",
     "require-sri": ["error", { target: "crossorigin" }],
   },
-};
+} satisfies Options;
 
 export function validateHtml(userOptions?: Options) {
   const options = merge(defaults, userOptions);

--- a/plugins/vento.ts
+++ b/plugins/vento.ts
@@ -57,7 +57,7 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".vento", ".vto"],
   autoTrim: true,
   options: {
@@ -65,7 +65,7 @@ export const defaults: Options = {
     useWith: true,
     autoescape: false,
   },
-};
+} satisfies Options;
 
 class LumeLoader implements Loader {
   fs: FS;

--- a/plugins/yaml.ts
+++ b/plugins/yaml.ts
@@ -12,9 +12,9 @@ export interface Options {
 }
 
 // Default options
-export const defaults: Options = {
+export const defaults = {
   extensions: [".yaml", ".yml"],
-};
+} satisfies Options;
 
 /**
  * A plugin to load YAML data files and pages

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -2,7 +2,6 @@ import { assertSnapshot } from "../deps/snapshot.ts";
 import lume from "../mod.ts";
 import Server from "../core/server.ts";
 import { basename, fromFileUrl, join } from "../deps/path.ts";
-import { DeepPartial } from "../core/utils/object.ts";
 
 import type { Writer } from "../core/writer.ts";
 import type { default as Site, SiteOptions } from "../core/site.ts";
@@ -35,7 +34,7 @@ class TestWriter implements Writer {
 
 /** Create a new lume site using the "assets" path as cwd */
 export function getSite(
-  options: DeepPartial<SiteOptions> = {},
+  options: SiteOptions = {},
   pluginOptions = {},
   write = false,
 ): Site {


### PR DESCRIPTION
## Description

I recently suggested changing the signature of `merge()` to more accurately reflect how it works. My original idea was simple, and wouldn't have worked too well actually. So I wanted to see if I could find a proper solution that doesn't rely on overly complex type programming.

The new `merge()` function takes an additional type parameter `Def` for the defaults, which must extend `Partial<Type>`. Based on this type, the return type narrows `Type` so that all properties defined in `Def` become non-nullable recursively. So any options not covered by the defaults will remain nullable.

In order for this mechanism to work, the default options must not be typed like this: `const defaults: Options = {... }`. Instead, you have to use `const defaults = {... } satisfies Options`. This allows TypeScript to narrow the type of `defaults` as much as possible. You still get all the same type checking benefits.

I adapted all places where `merge()` is used and even found ones where it was missing. I also found some cases where the options interface reflected the internal state (such as the `SiteOptions`), which as you told me isn't how you want it to work. I agree, so I changed those, too.

I confirmed everything still works by running the tests and building my website with my dev version.

**This is a minor breaking change.** Default options typed like `const defaults: Options = {... }` will cause the `merge()` function to return the original `Options` type, which means optional properties will remain optional and may cause type errors. It takes a simple migration to `const defaults = {... } satisfies Options` to fix this.

### Check List

- [x] Have you read the
      [CODE OF CONDUCT](https://github.com/lumeland/lume/blob/master/CODE_OF_CONDUCT.md)
- [x] Have you read the document
      [CONTRIBUTING](https://github.com/lumeland/lume/blob/master/CONTRIBUTING.md)
  - [x] One pull request per feature. If you want to do more than one thing,
        send multiple pull request.
  - [x] Write tests.
  - [x] Run deno `fmt` to fix the code format before commit.
  - [ ] Document any change in the `CHANGELOG.md`.
